### PR TITLE
Provide more detailed messages when failing to spawn processes

### DIFF
--- a/sable_server/src/run.rs
+++ b/sable_server/src/run.rs
@@ -63,7 +63,11 @@ where
 
     let err = Command::new(exe.as_ref()).args(args).exec();
 
-    panic!("exec() failed on upgrade: {}", err);
+    panic!(
+        "exec() failed on {} upgrade: {}",
+        exe.as_ref().display(),
+        err
+    );
 }
 
 // The async entry point for the application. Because `run_server` can fork into the background
@@ -111,12 +115,13 @@ where
         }
         ShutdownAction::Restart => {
             server.shutdown().await;
+            let current_exe = env::current_exe().context("Could not get current executable")?;
 
-            let err = Command::new(env::current_exe()?)
+            let err = Command::new(&current_exe)
                 .args(env::args().skip(1).collect::<Vec<_>>())
                 .exec();
 
-            panic!("Couldn't re-execute: {}", err);
+            panic!("Couldn't re-execute {}: {}", current_exe.display(), err);
         }
         ShutdownAction::Upgrade => {
             let server_state = server.save().await.context("Could not save server state")?;


### PR DESCRIPTION
Before:

```
Error: Could not initialize server

Caused by:
    0: Could not initialize server
    1: Could not initialize listener collection
    2: No such file or directory (os error 2)
```

After:

```
Error: Could not initialize server

Caused by:
    0: Could not initialize server
    1: Could not initialize listener collection
    2: Could not spawn /home/dev-sable/.cargo/bin/listener_process: No such file or directory (os error 2)
```

(both examples assume #23 is merged first)