### PR TITLE
Remove empty lines between 'Sending to ...' trace logs

### DIFF
--- a/sable_ircd/src/client.rs
+++ b/sable_ircd/src/client.rs
@@ -181,7 +181,11 @@ impl ClientConnection {
 impl MessageSink for ClientConnection {
     fn send(&self, msg: messages::OutboundClientMessage) {
         if let Some(formatted) = msg.format_for_client_caps((&self.capabilities).into()) {
-            tracing::trace!("Sending to {:?}: {}", self.id(), formatted);
+            tracing::trace!(
+                "Sending to {:?}: {}",
+                self.id(),
+                formatted.strip_suffix("\r\n").unwrap_or(&formatted)
+            );
             self.connection.send(formatted)
         }
     }


### PR DESCRIPTION
Before:

```
2023-08-25T15:43:06.867204Z TRACE do_run: sable_ircd::server: ...from history_receiver res=Some(NewEntry(2))
2023-08-25T15:43:06.867220Z TRACE do_run: sable_ircd::server::update_handler: Got history update update=NewEntry(2)
2023-08-25T15:43:06.867253Z TRACE do_run: sable_ircd::client: Sending to ConnectionId(ListenerId(0), 2): :My.Little.Server 001 bar :Welcome to the test Internet Relay Chat network, bar

2023-08-25T15:43:06.867270Z TRACE do_run: sable_ircd::client: Sending to ConnectionId(ListenerId(0), 2): :My.Little.Server 002 bar :Your host is My.Little.Server, running version sable-0.1.0-67731f09bd30e9a4db1083cd30491353e6712d2c

2023-08-25T15:43:06.867309Z TRACE do_run: sable_ircd::client: Sending to ConnectionId(ListenerId(0), 2): :My.Little.Server 005 bar EXCEPTS INVEX FNC CASEMAPPING=ascii CHANMODES=bqeI,k,,ntsi PREFIX=(ov)@+ :are supported by this server

2023-08-25T15:43:06.867327Z TRACE do_run: sable_ircd::client: Sending to ConnectionId(ListenerId(0), 2): :bar!username@magnesium.home MODE bar +

2023-08-25T15:43:06.867340Z TRACE do_run: sable_ircd::client: Sending to ConnectionId(ListenerId(0), 2): :My.Little.Server NOTICE bar :The network is currently running in debug mode. Do not send any sensitive information such as passwords.
```

After:

```
2023-08-25T15:51:11.307077Z TRACE do_run: sable_ircd::server: ...from history_receiver res=Some(NewEntry(2))
2023-08-25T15:51:11.307098Z TRACE do_run: sable_ircd::server::update_handler: Got history update update=NewEntry(2)
2023-08-25T15:51:11.307142Z TRACE do_run: sable_ircd::client: Sending to ConnectionId(ListenerId(0), 2): :My.Little.Server 001 bar :Welcome to the test Internet Relay Chat network, bar
2023-08-25T15:51:11.307176Z TRACE do_run: sable_ircd::client: Sending to ConnectionId(ListenerId(0), 2): :My.Little.Server 002 bar :Your host is My.Little.Server, running version sable-0.1.0-67731f09bd30e9a4db1083cd30491353e6712d2c
2023-08-25T15:51:11.307222Z TRACE do_run: sable_ircd::client: Sending to ConnectionId(ListenerId(0), 2): :My.Little.Server 005 bar EXCEPTS INVEX FNC CASEMAPPING=ascii CHANMODES=bqeI,k,,ntsi PREFIX=(ov)@+ :are supported by this server
2023-08-25T15:51:11.307259Z TRACE do_run: sable_ircd::client: Sending to ConnectionId(ListenerId(0), 2): :bar!username@magnesium.home MODE bar +
2023-08-25T15:51:11.307289Z TRACE do_run: sable_ircd::client: Sending to ConnectionId(ListenerId(0), 2): :My.Little.Server NOTICE bar :The network is currently running in debug mode. Do not send any sensitive information such as passwords.
```