### PR TITLE
Reply to successful OPER with RPL_YOUREOPER

### DIFF
--- a/sable_ircd/src/command/handlers/oper.rs
+++ b/sable_ircd/src/command/handlers/oper.rs
@@ -3,6 +3,7 @@ use event::*;
 
 #[command_handler("OPER")]
 fn handle_oper(
+    response: &dyn CommandResponse,
     server: &ClientServer,
     net: &Network,
     source: UserSource,
@@ -16,6 +17,7 @@ fn handle_oper(
         if server.policy().authenticate(conf, oper_name, password) {
             audit.general().log();
 
+            response.numeric(make_numeric!(YoureOper));
             server.add_action(CommandAction::state_change(
                 source.id(),
                 details::OperUp {

--- a/sable_ircd/src/messages/numeric.rs
+++ b/sable_ircd/src/messages/numeric.rs
@@ -37,6 +37,8 @@ define_messages! {
                                                                 => "{is_pub} {chan} :{content}" },
     366(EndOfNames)             => { (chan: &Channel.name())    => "{chan} :End of names list" },
 
+    381(YoureOper)              => { ()                         => "You are now an IRC operator" },
+
 
     401(NoSuchTarget)           => { (unknown: &str)            => "{unknown} :No such nick/channel" },
     403(NoSuchChannel)          => { (chname: &ChannelName)     => "{chname} :No such channel" },


### PR DESCRIPTION
In addition to `MODE <user> +o` (which isn't a labeled-response, but sent asynchronously).

Numeric 381 is the standard way to notified clients they successfully opered up: https://modern.ircdocs.horse/#oper-message