### PR TITLE
labeled-response: Avoid sending batches for single messages

### DIFF
--- a/sable_ircd/src/messages/mod.rs
+++ b/sable_ircd/src/messages/mod.rs
@@ -82,6 +82,10 @@ impl OutboundClientMessage {
         }
     }
 
+    pub fn tags(&self) -> &Vec<OutboundMessageTag> {
+        &self.tags
+    }
+
     /// Add a message tag to the message
     pub fn with_tag(mut self, tag: OutboundMessageTag) -> Self {
         self.tags.push(tag);


### PR DESCRIPTION
This is not strictly necessary, but it is slightly annoying when manually debugging from a client and wasted space on my terminal. :)

This replaces the `send_count` atomic counter with a `OnceLock` and turns `sent_start` from a spinlock into a `Once` because we need to hold the lock while the first message is being sent, now.