### PR TITLE
Send ERROR reply to QUIT commands

### DIFF
--- a/sable_ircd/src/command/handlers/quit.rs
+++ b/sable_ircd/src/command/handlers/quit.rs
@@ -1,7 +1,13 @@
 use super::*;
 
 #[command_handler("QUIT")]
-fn handle_quit(server: &ClientServer, source: UserSource, msg: Option<&str>) -> CommandResult {
+fn handle_quit(
+    server: &ClientServer,
+    source: UserSource,
+    response: &dyn CommandResponse,
+    msg: Option<&str>,
+) -> CommandResult {
+    response.send(message::Error::new("Client quit"));
     server.add_action(CommandAction::DisconnectUser(source.id()));
     server.add_action(CommandAction::state_change(
         source.id(),


### PR DESCRIPTION
This is recommended by https://datatracker.ietf.org/doc/html/rfc2812#section-3.1.7 and is consistent with Ergo, InspIRCd, Solanum, and UnrealIRCd.