### PR TITLE
Reply to invalid CAP subcommands with ERR_INVALIDCAPCMD

### DIFF
--- a/sable_ircd/src/command/handlers/cap.rs
+++ b/sable_ircd/src/command/handlers/cap.rs
@@ -71,7 +71,10 @@ fn handle_cap(
             }
             Ok(())
         }
-        _ => Ok(()),
+        _ => {
+            response.numeric(make_numeric!(InvalidCapCmd, subcommand));
+            Ok(())
+        }
     }
 }
 

--- a/sable_ircd/src/messages/numeric.rs
+++ b/sable_ircd/src/messages/numeric.rs
@@ -42,6 +42,7 @@ define_messages! {
     401(NoSuchTarget)           => { (unknown: &str)            => "{unknown} :No such nick/channel" },
     403(NoSuchChannel)          => { (chname: &ChannelName)     => "{chname} :No such channel" },
     404(CannotSendToChannel)    => { (chan: &ChannelName)       => "{chan} :Cannot send to channel" },
+    410(InvalidCapCmd)          => { (subcommand: &str)         => "{subcommand} :Invalid CAP command" },
     421(UnknownCommand)         => { (command: &str)            => "{command} :Unknown command" },
     432(ErroneousNickname)      => { (nick: &str)               => "{nick} :Erroneous nickname" },
     433(NicknameInUse)          => { (nick: &Nickname)          => "{nick} :Nickname is already in use." },


### PR DESCRIPTION
As required by https://ircv3.net/specs/extensions/capability-negotiation#the-cap-command