### PR TITLE
Fix IRCv3 clients being registered before CAP END

### DIFF
--- a/sable_ircd/src/client.rs
+++ b/sable_ircd/src/client.rs
@@ -53,8 +53,8 @@ pub(super) struct ClientConnectionState {
 #[derive(Debug, Clone, Copy)]
 #[repr(u32)]
 pub enum ProgressFlag {
-    CapNegotiation,
-    SaslAuthentication,
+    CapNegotiation = 0x1,
+    SaslAuthentication = 0x2,
 }
 
 /// Information received from a client connection that has not yet completed registration


### PR DESCRIPTION
ProgressFlag::CapNegotiation had its value set to 0, so no bit was set in the progress bitfield, causing registration to proceed as soon as a message was received after NICK+USER