### PR TITLE
Use a valid DNS domain name for vendored capabilities

### DIFF
--- a/sable_ircd/src/capability/mod.rs
+++ b/sable_ircd/src/capability/mod.rs
@@ -72,8 +72,8 @@ define_capabilities! (
         LabeledResponse:        0x20 => ("labeled-response", true),
 
         ChatHistory:            0x101 => ("draft/chathistory", true),
-        PersistentSession:      0x102 => ("sable/persistent-session", true),
-        AccountRegistration:    0x104 => ("sable/account-registration", true)
+        PersistentSession:      0x102 => ("sable.libera.chat/persistent-session", true),
+        AccountRegistration:    0x104 => ("sable.libera.chat/account-registration", true)
     }
 );
 


### PR DESCRIPTION
As required by https://ircv3.net/specs/extensions/capability-negotiation#vendor-specific-capabilities