### PR TITLE
Fix CAP REQ unsetting previously enabled capabilities

### DIFF
--- a/sable_ircd/src/capability/mod.rs
+++ b/sable_ircd/src/capability/mod.rs
@@ -148,10 +148,6 @@ impl AtomicCapabilitySet {
         self.0.fetch_and(!(cap as u64), Ordering::Relaxed);
     }
 
-    pub fn reset(&self, caps: ClientCapabilitySet) {
-        self.0.store(caps.0, Ordering::Relaxed);
-    }
-
     pub fn iter<'a>(&'a self) -> impl Iterator<Item = ClientCapability> + 'a {
         ClientCapability::ALL
             .iter()

--- a/sable_ircd/src/server/command_action.rs
+++ b/sable_ircd/src/server/command_action.rs
@@ -67,7 +67,7 @@ impl ClientServer {
 
             CommandAction::UpdateConnectionCaps(conn_id, new_caps) => {
                 if let Ok(connection) = self.connections.get(conn_id) {
-                    connection.capabilities.reset(new_caps);
+                    connection.capabilities.set_all(new_caps);
                 }
             }
 


### PR DESCRIPTION
Capabilities should only be unset when the client prefixes them with a dash or the server sends CAP DEL to clients.

https://ircv3.net/specs/extensions/capability-negotiation#the-cap-req-subcommand