### PR TITLE
Add support for PART with no message

### DIFF
--- a/sable_ircd/src/command/handlers/part.rs
+++ b/sable_ircd/src/command/handlers/part.rs
@@ -6,12 +6,12 @@ fn handle_part(
     net: &Network,
     source: UserSource,
     channel: wrapper::Channel,
-    msg: &str,
+    msg: Option<&str>,
 ) -> CommandResult {
     let membership_id = MembershipId::new(source.id(), channel.id());
     if net.membership(membership_id).is_ok() {
         let details = event::ChannelPart {
-            message: msg.to_owned(),
+            message: msg.unwrap_or(source.nick().as_ref()).to_owned(),
         };
         server.add_action(CommandAction::state_change(membership_id, details));
     } else {


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc2812#section-3.2.2 recommends using the nick as the replacement, and all implementations seem to do it.