### PR TITLE
Fix server-time tag name

### DIFF
--- a/sable_ircd/src/capability/server_time.rs
+++ b/sable_ircd/src/capability/server_time.rs
@@ -4,7 +4,7 @@ use crate::utils::format_timestamp;
 
 pub fn server_time_tag(ts: i64) -> OutboundMessageTag {
     OutboundMessageTag::new(
-        "server-time",
+        "time",
         Some(format_timestamp(ts)),
         ClientCapability::ServerTime,
     )


### PR DESCRIPTION
'server-time' is the cap/spec name, not the tag name: https://ircv3.net/specs/extensions/server-time