### PR TITLE
Implement MOTD command

### DIFF
--- a/configs/server1.conf
+++ b/configs/server1.conf
@@ -14,7 +14,8 @@
         "listeners": [
             { "address": "127.0.1.2:6667" },
             { "address": "127.0.1.2:6697", "tls": true },
-        ]
+        ],
+        "motd": "configs/server1_motd.txt",
     },
 
     "tls_config": {

--- a/configs/server1_motd.txt
+++ b/configs/server1_motd.txt
@@ -1,0 +1,2 @@
+MOTD for server 1!
+- A_Dragon

--- a/configs/server2.conf
+++ b/configs/server2.conf
@@ -14,6 +14,7 @@
         "listeners": [
             { "address": "127.0.1.3:6667" }
         ]
+        // No MOTD
     },
 
     "tls_config": {

--- a/sable_ircd/src/command/handlers/motd.rs
+++ b/sable_ircd/src/command/handlers/motd.rs
@@ -2,12 +2,12 @@ use super::*;
 
 #[command_handler("MOTD")]
 fn handle_motd(server: &ClientServer, response: &dyn CommandResponse) -> CommandResult {
-    match &server.infos.motd {
+    match &server.info_strings.motd {
         None => response.numeric(make_numeric!(NoMotd)),
         Some(motd) => {
             response.numeric(make_numeric!(MotdStart, server.name()));
-            for line in motd.lines() {
-                response.numeric(make_numeric!(Motd, line));
+            for ele in motd {
+                response.numeric(make_numeric!(Motd, ele))
             }
 
             response.numeric(make_numeric!(EndOfMotd));

--- a/sable_ircd/src/command/handlers/motd.rs
+++ b/sable_ircd/src/command/handlers/motd.rs
@@ -1,0 +1,18 @@
+use super::*;
+
+#[command_handler("MOTD")]
+fn handle_motd(server: &ClientServer, response: &dyn CommandResponse) -> CommandResult {
+    match &server.infos.motd {
+        None => response.numeric(make_numeric!(NoMotd)),
+        Some(motd) => {
+            response.numeric(make_numeric!(MotdStart, server.name()));
+            for line in motd.lines() {
+                response.numeric(make_numeric!(Motd, line));
+            }
+
+            response.numeric(make_numeric!(EndOfMotd));
+        }
+    }
+
+    Ok(())
+}

--- a/sable_ircd/src/command/mod.rs
+++ b/sable_ircd/src/command/mod.rs
@@ -44,6 +44,7 @@ mod handlers {
     mod kill;
     mod kline;
     mod mode;
+    mod motd;
     mod names;
     mod nick;
     mod notice;

--- a/sable_ircd/src/messages/numeric.rs
+++ b/sable_ircd/src/messages/numeric.rs
@@ -43,6 +43,7 @@ define_messages! {
     375(MotdStart)              => { (server_name: &ServerName)        => ":- {server_name} message of the day -"},
     372(Motd)                   => { (line: &str)               => ":{line}"},
     376(EndOfMotd)              => { ()                         => ":End of MOTD" },
+
     381(YoureOper)              => { ()                         => "You are now an IRC operator" },
 
 

--- a/sable_ircd/src/messages/numeric.rs
+++ b/sable_ircd/src/messages/numeric.rs
@@ -39,10 +39,15 @@ define_messages! {
                                                                 => "{is_pub} {chan} :{content}" },
     366(EndOfNames)             => { (chname: &str)             => "{chname} :End of names list" },
 
+    422(NoMotd)                 => { ()                         => ":MOTD File is missing"},
+    375(MotdStart)              => { (server_name: &ServerName)        => ":- {server_name} message of the day -"},
+    372(Motd)                   => { (line: &str)               => ":{line}"},
+    376(EndOfMotd)              => { ()                         => ":End of MOTD" },
     381(YoureOper)              => { ()                         => "You are now an IRC operator" },
 
 
     401(NoSuchTarget)           => { (unknown: &str)            => "{unknown} :No such nick/channel" },
+    402(NoSuchServer)           => { (server_name: &ServerName) => "{server_name} :No such server" },
     403(NoSuchChannel)          => { (chname: &ChannelName)     => "{chname} :No such channel" },
     404(CannotSendToChannel)    => { (chan: &ChannelName)       => "{chan} :Cannot send to channel" },
     410(InvalidCapCmd)          => { (subcommand: &str)         => "{subcommand} :Invalid CAP command" },

--- a/sable_ircd/src/server/config.rs
+++ b/sable_ircd/src/server/config.rs
@@ -17,7 +17,7 @@ pub struct InfoPaths {
 }
 
 #[derive(Debug, Deserialize, Clone)]
-pub struct ClientServerConfig {
+pub struct RawClientServerConfig {
     pub listeners: Vec<ListenerConfig>,
     #[serde(flatten)]
     pub info_paths: InfoPaths,
@@ -55,7 +55,7 @@ impl ServerInfoStrings {
     }
 }
 
-pub struct ProcessedCSConfig {
+pub struct ClientServerConfig {
     pub listeners: Vec<ListenerConfig>,
     pub info_strings: ServerInfoStrings,
 }

--- a/sable_ircd/src/server/config.rs
+++ b/sable_ircd/src/server/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::{fmt::Display, fs};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ListenerConfig {
@@ -22,6 +22,7 @@ pub struct ClientServerConfig {
     pub info_paths: InfoPaths,
 }
 
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Infos {
     pub motd: Option<String>, // Linewise to not repeatedly split
 }

--- a/sable_ircd/src/server/config.rs
+++ b/sable_ircd/src/server/config.rs
@@ -1,3 +1,6 @@
+use std::path::PathBuf;
+use std::{fmt::Display, fs};
+
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -8,6 +11,61 @@ pub struct ListenerConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+pub struct InfoPaths {
+    pub motd: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
 pub struct ClientServerConfig {
     pub listeners: Vec<ListenerConfig>,
+    #[serde(flatten)]
+    pub info_paths: InfoPaths,
+}
+
+pub struct Infos {
+    pub motd: Option<String>, // Linewise to not repeatedly split
+}
+
+impl Infos {
+    pub fn load(paths: &InfoPaths) -> Result<Infos, ConfigProcessingError> {
+        Ok(Self {
+            motd: Self::get_info(&paths.motd, "motd")?,
+        })
+    }
+
+    fn get_info(
+        path: &Option<PathBuf>,
+        name: &str,
+    ) -> Result<Option<String>, ConfigProcessingError> {
+        match path {
+            Some(real_path) => Ok(Some(Self::read(&real_path, name)?)),
+            None => Ok(None),
+        }
+    }
+
+    fn read(path: &PathBuf, name: &str) -> Result<String, ConfigProcessingError> {
+        fs::read_to_string(path).or_else(|err| {
+            Err(ConfigProcessingError {
+                reason: format!("Unable to read info {name:?} from {path:?}: {err}"),
+            })
+        })
+    }
+}
+
+pub struct ProcessedCSConfig {
+    pub listeners: Vec<ListenerConfig>,
+    pub infos: Infos,
+}
+
+#[derive(Debug)]
+pub struct ConfigProcessingError {
+    reason: String,
+}
+
+impl std::error::Error for ConfigProcessingError {}
+
+impl Display for ConfigProcessingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("Unable to process config: {}", self.reason))
+    }
 }

--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -35,7 +35,10 @@ pub use async_handler_collection::*;
 
 mod upgrade;
 
-use self::{config::ClientServerConfig, message_sink_repository::MessageSinkRepository};
+use self::{
+    config::{ClientServerConfig, Infos},
+    message_sink_repository::MessageSinkRepository,
+};
 
 pub mod config;
 
@@ -76,6 +79,9 @@ pub struct ClientServer {
 
     node: Arc<NetworkNode>,
     listeners: Movable<ListenerCollection>,
+
+    // Any general static info (responses for MOTD, ADMIN, and so on)
+    pub infos: Infos,
 }
 
 impl ClientServer {

--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -36,7 +36,7 @@ pub use async_handler_collection::*;
 mod upgrade;
 
 use self::{
-    config::{ClientServerConfig, ServerInfoStrings},
+    config::{RawClientServerConfig, ServerInfoStrings},
     message_sink_repository::MessageSinkRepository,
 };
 

--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -36,7 +36,7 @@ pub use async_handler_collection::*;
 mod upgrade;
 
 use self::{
-    config::{ClientServerConfig, Infos},
+    config::{ClientServerConfig, ServerInfoStrings},
     message_sink_repository::MessageSinkRepository,
 };
 
@@ -81,7 +81,7 @@ pub struct ClientServer {
     listeners: Movable<ListenerCollection>,
 
     // Any general static info (responses for MOTD, ADMIN, and so on)
-    pub infos: Infos,
+    pub info_strings: ServerInfoStrings,
 }
 
 impl ClientServer {

--- a/sable_ircd/src/server/server_type.rs
+++ b/sable_ircd/src/server/server_type.rs
@@ -12,7 +12,7 @@ pub struct ClientServerState {
     auth_state: AuthClientState,
     client_caps: CapabilityRepository,
     listener_state: SavedListenerCollection,
-    infos: config::Infos,
+    info_strings: config::ServerInfoStrings,
 }
 
 #[async_trait]
@@ -28,7 +28,7 @@ impl sable_server::ServerType for ClientServer {
     ) -> Result<Self::ProcessedConfig, Self::ConfigError> {
         Ok(Self::ProcessedConfig {
             listeners: config.listeners.clone(),
-            infos: Infos::load(&config.info_paths)?,
+            info_strings: ServerInfoStrings::load(&config.info_paths)?,
         })
     }
 
@@ -85,7 +85,7 @@ impl sable_server::ServerType for ClientServer {
             client_caps: CapabilityRepository::new(),
             node: node,
             listeners: Movable::new(client_listeners),
-            infos: config.infos,
+            info_strings: config.info_strings,
         })
     }
 
@@ -106,7 +106,7 @@ impl sable_server::ServerType for ClientServer {
                 .save()
                 .await
                 .map_err(ServerSaveError::IoError)?,
-            infos: self.infos,
+            info_strings: self.info_strings,
         })
     }
 
@@ -146,7 +146,7 @@ impl sable_server::ServerType for ClientServer {
             client_caps: state.client_caps,
             history_receiver: Mutex::new(history_receiver),
             listeners: Movable::new(listeners),
-            infos: state.infos,
+            info_strings: state.info_strings,
         })
     }
 

--- a/sable_ircd/src/server/server_type.rs
+++ b/sable_ircd/src/server/server_type.rs
@@ -1,4 +1,3 @@
-use super::config::Infos;
 use super::*;
 use crate::connection_collection::ConnectionCollectionState;
 use anyhow::Context;
@@ -13,6 +12,7 @@ pub struct ClientServerState {
     auth_state: AuthClientState,
     client_caps: CapabilityRepository,
     listener_state: SavedListenerCollection,
+    infos: config::Infos,
 }
 
 #[async_trait]
@@ -106,6 +106,7 @@ impl sable_server::ServerType for ClientServer {
                 .save()
                 .await
                 .map_err(ServerSaveError::IoError)?,
+            infos: self.infos,
         })
     }
 
@@ -145,7 +146,7 @@ impl sable_server::ServerType for ClientServer {
             client_caps: state.client_caps,
             history_receiver: Mutex::new(history_receiver),
             listeners: Movable::new(listeners),
-            infos: Infos { motd: None },
+            infos: state.infos,
         })
     }
 

--- a/sable_ircd/src/server/server_type.rs
+++ b/sable_ircd/src/server/server_type.rs
@@ -17,14 +17,14 @@ pub struct ClientServerState {
 
 #[async_trait]
 impl sable_server::ServerType for ClientServer {
-    type Config = ClientServerConfig;
-    type ProcessedConfig = config::ProcessedCSConfig;
+    type Config = RawClientServerConfig;
+    type ProcessedConfig = config::ClientServerConfig;
     type ConfigError = config::ConfigProcessingError;
 
     type Saved = ClientServerState;
 
     fn validate_config(
-        config: &ClientServerConfig,
+        config: &RawClientServerConfig,
     ) -> Result<Self::ProcessedConfig, Self::ConfigError> {
         Ok(Self::ProcessedConfig {
             listeners: config.listeners.clone(),


### PR DESCRIPTION
Adds support for [/MOTD](https://modern.ircdocs.horse/#motd-message). This uses the config processing system added by @spb  in 8d37fdaf2dc7efe033e031cfda8a0fa96182e821

The reading of the config is done once at startup, rehashes are not included in this PR.
The infos config allows for infos to be omitted entirely, resulting in None. If an infos entry is included in the config, but _not_ a valid path on disk, sable will fail to start with a reasonable error