### PR TITLE
Remove message-tags capability

### DIFF
--- a/sable_ircd/src/capability/mod.rs
+++ b/sable_ircd/src/capability/mod.rs
@@ -64,7 +64,6 @@ macro_rules! define_capabilities {
 define_capabilities! (
     ClientCapability
     {
-        MessageTags:            0x01 => ("message-tags", true),
         ServerTime:             0x02 => ("server-time", true),
         EchoMessage:            0x04 => ("echo-message", true),
         Sasl:                   0x08 => ("sasl", false),


### PR DESCRIPTION
As far as I can tell it is not implemented yet: TAGMSG is rejected as invalid command, and client tags are not relayed.