### PR TITLE
Make pattern-matching case-insensitive

### DIFF
--- a/sable_network/src/types/pattern.rs
+++ b/sable_network/src/types/pattern.rs
@@ -47,6 +47,6 @@ impl Pattern {
     /// Test whether the given string matches this pattern. Note that this is always
     /// case-insensitive
     pub fn matches(&self, s: &str) -> bool {
-        WildMatch::new(&self.0).matches(s)
+        WildMatch::new(&self.0.to_ascii_lowercase()).matches(&s.to_ascii_lowercase())
     }
 }


### PR DESCRIPTION
eg. `MODE +b bar!*@*` should ban users with nick `Bar`.

to_ascii_lowercase() matches the case-folding algorithm already in use in Sable (eg. eq_ignore_ascii_case() for identifier comparison)