### PR TITLE
NAMES: Return EndOfNames even on invalid and non-existant channel names

### DIFF
--- a/sable_ircd/src/command/handlers/names.rs
+++ b/sable_ircd/src/command/handlers/names.rs
@@ -5,9 +5,18 @@ fn handle_names(
     server: &ClientServer,
     response: &dyn CommandResponse,
     source: UserSource,
-    channel: wrapper::Channel,
+    channel: &str,
 ) -> CommandResult {
-    crate::utils::send_channel_names(server, &response, &source, &channel)?;
+    if let Ok(channel_name) = &ChannelName::from_str(channel) {
+        if let Ok(channel) = server.network().channel_by_name(channel_name) {
+            crate::utils::send_channel_names(server, &response, &source, &channel)?;
+            return Ok(());
+        }
+    }
+
+    // "If the channel name is invalid or the channel does not exist, one RPL_ENDOFNAMES numeric
+    // containing the given channel name should be returned." -- https://modern.ircdocs.horse/#names-message
+    response.numeric(make_numeric!(EndOfNames, channel));
 
     Ok(())
 }

--- a/sable_ircd/src/messages/numeric.rs
+++ b/sable_ircd/src/messages/numeric.rs
@@ -34,7 +34,7 @@ define_messages! {
                                                 => "{chname} {user} {host} {server} {nick} {status} :{hopcount} {realname}" },
     353(NamesReply)             => { (is_pub: char, chan: &Channel.name(), content: &str)
                                                                 => "{is_pub} {chan} :{content}" },
-    366(EndOfNames)             => { (chan: &Channel.name())    => "{chan} :End of names list" },
+    366(EndOfNames)             => { (chname: &str)             => "{chname} :End of names list" },
 
     381(YoureOper)              => { ()                         => "You are now an IRC operator" },
 

--- a/sable_ircd/src/utils/channel_names.rs
+++ b/sable_ircd/src/utils/channel_names.rs
@@ -58,6 +58,6 @@ pub fn send_channel_names(
             numeric::NamesReply::new(pub_or_secret, channel, &line).format_for(server, to_user),
         );
     }
-    to.send(numeric::EndOfNames::new(channel).format_for(server, to_user));
+    to.send(numeric::EndOfNames::new(channel.name().value()).format_for(server, to_user));
     Ok(())
 }


### PR DESCRIPTION
Unbelievably, this is what the specs say and every other server follows it:

> If the channel name is invalid or the channel does not exist, one RPL_ENDOFNAMES numeric containing the given channel name should be returned.

-- https://modern.ircdocs.horse/#names-message