### PR TITLE
Allow unsetting topics with `TOPIC #chan :`

### DIFF
--- a/sable_ircd/src/client_message.rs
+++ b/sable_ircd/src/client_message.rs
@@ -78,9 +78,7 @@ impl ClientMessage {
 
         loop {
             if let Some(arg) = rest.strip_prefix(':') {
-                if !arg.is_empty() {
-                    args.push(arg.to_string());
-                }
+                args.push(arg.to_string());
                 break;
             }
 
@@ -148,7 +146,7 @@ mod tests {
     fn ending_colon() {
         let msg = ClientMessage::parse(get_connid(), "command arg1 arg2 :").unwrap();
 
-        assert_eq!(msg.args, &["arg1", "arg2"]);
+        assert_eq!(msg.args, &["arg1", "arg2", ""]);
     }
 
     #[test]

--- a/sable_ircd/src/command/handlers/notice.rs
+++ b/sable_ircd/src/command/handlers/notice.rs
@@ -8,6 +8,10 @@ async fn handle_notice(
     target: TargetParameter<'_>,
     msg: &str,
 ) -> CommandResult {
+    if msg.len() == 0 {
+        return numeric_error!(NoTextToSend);
+    }
+
     if let Some(user) = target.user() {
         if user.is_alias_user().is_some() {
             // This is a notice which doesn't expect a response; drop it

--- a/sable_ircd/src/command/handlers/privmsg.rs
+++ b/sable_ircd/src/command/handlers/privmsg.rs
@@ -8,6 +8,10 @@ async fn handle_privmsg(
     target: TargetParameter<'_>,
     msg: &str,
 ) -> CommandResult {
+    if msg.len() == 0 {
+        return numeric_error!(NoTextToSend);
+    }
+
     if let Some(user) = target.user() {
         if let Some(alias) = user.is_alias_user() {
             return super::services::dispatch_alias_command(cmd, &user, &alias.command_alias, msg)

--- a/sable_ircd/src/messages/numeric.rs
+++ b/sable_ircd/src/messages/numeric.rs
@@ -43,6 +43,7 @@ define_messages! {
     403(NoSuchChannel)          => { (chname: &ChannelName)     => "{chname} :No such channel" },
     404(CannotSendToChannel)    => { (chan: &ChannelName)       => "{chan} :Cannot send to channel" },
     410(InvalidCapCmd)          => { (subcommand: &str)         => "{subcommand} :Invalid CAP command" },
+    412(NoTextToSend)           => { ()                         => ":No text to send" },
     421(UnknownCommand)         => { (command: &str)            => "{command} :Unknown command" },
     432(ErroneousNickname)      => { (nick: &str)               => "{nick} :Erroneous nickname" },
     433(NicknameInUse)          => { (nick: &Nickname)          => "{nick} :Nickname is already in use." },


### PR DESCRIPTION
Before this commit, empty trailings were treated like omitting the trailing by the parser, which prevents unsetting topics.

Consequently, this commit changes NOTICE and PRIVMSG command handlers to issue errors themselves on empty trailing.
This is also an issue with channel keys, which are handled by #62

Closes #56.