### PR TITLE
Default-allow ops to invite

### DIFF
--- a/configs/network_config.json
+++ b/configs/network_config.json
@@ -33,6 +33,7 @@
             "ban_view", "ban_add", "ban_remove_any",
             "quiet_view", "quiet_add", "quiet_remove_any",
             "exempt_view", "exempt_add", "exempt_remove_any",
+            "invite_self", "invite_other",
             "invex_view", "invex_add", "invex_remove_any"
         ],
         "builtin:voice": [


### PR DESCRIPTION
Replaces #48 without the extra configurability