### PR TITLE
Return ERROR command before closing connection due to connection error

### DIFF
--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -248,6 +248,7 @@ impl ClientServer {
                             .await;
                         }
                     }
+                    conn.send(message::Error::new(&e.to_string()));
                 }
                 self.connections.write().remove(msg.source);
             }


### PR DESCRIPTION
It's better than nothing, eg. when the error is 'I/O Error: stream did not contain valid UTF-8'