### PR TITLE
Ignore PONG commands

### DIFF
--- a/sable_ircd/src/command/handlers/pong.rs
+++ b/sable_ircd/src/command/handlers/pong.rs
@@ -1,0 +1,6 @@
+use super::*;
+
+#[command_handler("PONG")]
+fn away_handler() -> CommandResult {
+    Ok(())
+}

--- a/sable_ircd/src/command/mod.rs
+++ b/sable_ircd/src/command/mod.rs
@@ -53,6 +53,7 @@ mod handlers {
     mod oper;
     mod part;
     mod ping;
+    mod pong;
     mod privmsg;
     mod quit;
     pub mod register;


### PR DESCRIPTION
Not much point to it as Sable doesn't send PINGs, but it's an easy way to test Sable answers with ACK when labeled-response is enabled