### PR TITLE
Consistently access TargetParameter by pattern-matching

### DIFF
--- a/sable_ircd/src/command/handlers/notice.rs
+++ b/sable_ircd/src/command/handlers/notice.rs
@@ -36,16 +36,18 @@ async fn handle_notice(
         return Ok(());
     }
 
-    if let Some(user) = target.user() {
-        if user.is_alias_user().is_some() {
-            // This is a notice which doesn't expect a response; drop it
-            return Ok(());
+    match &target {
+        TargetParameter::User(user) => {
+            if user.is_alias_user().is_some() {
+                // This is a notice which doesn't expect a response; drop it
+                return Ok(());
+            }
         }
-    }
-    if let Some(channel) = target.channel() {
-        if server.policy().can_send(&source, &channel, msg).is_err() {
-            // Silent error, see above
-            return Ok(());
+        TargetParameter::Channel(channel) => {
+            if server.policy().can_send(&source, &channel, msg).is_err() {
+                // Silent error, see above
+                return Ok(());
+            }
         }
     }
 

--- a/sable_ircd/src/command/plumbing/target_types.rs
+++ b/sable_ircd/src/command/plumbing/target_types.rs
@@ -8,20 +8,6 @@ pub enum TargetParameter<'a> {
 }
 
 impl TargetParameter<'_> {
-    pub fn user(&self) -> Option<&wrapper::User> {
-        match self {
-            Self::User(u) => Some(&u),
-            Self::Channel(_) => None,
-        }
-    }
-
-    pub fn channel(&self) -> Option<&wrapper::Channel> {
-        match self {
-            Self::User(_) => None,
-            Self::Channel(c) => Some(&c),
-        }
-    }
-
     pub fn object_id(&self) -> ObjectId {
         match self {
             Self::User(u) => u.id().into(),


### PR DESCRIPTION
This is already done this way in the MODE handler, and it's probably better to always check for exhaustiveness instead of chaining 'if' blocks