### PR TITLE
Use exponential backoff in ReplicatedEventLog::start_sync_to_network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +1991,7 @@ dependencies = [
  "ambassador",
  "anyhow",
  "arrayvec",
+ "backoff",
  "bitflags",
  "built",
  "chrono",

--- a/sable_network/Cargo.toml
+++ b/sable_network/Cargo.toml
@@ -42,6 +42,7 @@ concurrent_log = { version = "0.2.4", features = [ "serde" ] }
 once_cell = "1.13"
 ipnet = { version = "2", features = [ "serde" ] }
 anyhow = "1.0"
+backoff = { version = "0.4.0", features = ["tokio"] }
 
 [dependencies.serde]
 version = "1"


### PR DESCRIPTION
This allows using a shorter initial interval without spammer requests, so bootstrapping a large network is faster.

For example, bootstrapping a 5-nodes network now takes ~2 seconds instead of 5-20s.