### PR TITLE
Add missing RPL_LOGGEDIN reply to successful AUTHENTICATE

### DIFF
--- a/sable_ircd/src/command/handlers/services/sasl.rs
+++ b/sable_ircd/src/command/handlers/services/sasl.rs
@@ -58,9 +58,17 @@ async fn handle_authenticate(
                     };
                     response.send(message::Authenticate::new(&client_data));
                 }
-                Success(account) => {
-                    source.sasl_account.set(account).ok();
+                Success(account_id) => {
+                    source.sasl_account.set(account_id).ok();
 
+                    match net.account(account_id) {
+                        Ok(account) => response.numeric(make_numeric!(LoggedIn, &account.name())),
+                        Err(err) => tracing::error!(
+                            "Successfully logged in to non-existant account {:?}: {:?}",
+                            account_id,
+                            err
+                        ),
+                    }
                     response.numeric(make_numeric!(SaslSuccess));
                 }
                 Fail => {

--- a/sable_ircd/src/messages/numeric.rs
+++ b/sable_ircd/src/messages/numeric.rs
@@ -108,6 +108,7 @@ define_messages! {
 
     440(ServicesNotAvailable) => { () => ":Services are not available"},
 
+    900(LoggedIn)           => { (account: &Nickname) => "* {account} :You are now logged in as {account}" },  // TODO: <nick>!<ident>@<host> instead of *
     903(SaslSuccess)        => { () => ":SASL authentication successful" },
     904(SaslFail)           => { () => ":SASL authentication failed" },
     906(SaslAborted)        => { () => ":SASL authentication aborted" }


### PR DESCRIPTION
It's excessively annoying to generate `<nick>!<ident>@<host>` for a pre-client, so I'm leaving it out, at least for now