### PR TITLE
Fix timestamp format to include milliseconds

### DIFF
--- a/sable_ircd/src/utils/time_utils.rs
+++ b/sable_ircd/src/utils/time_utils.rs
@@ -3,7 +3,7 @@ use chrono::prelude::*;
 pub fn format_timestamp(ts: i64) -> String {
     Utc.timestamp_opt(ts, 0)
         .unwrap()
-        .to_rfc3339_opts(SecondsFormat::Secs, true)
+        .to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 
 pub fn parse_timestamp(str: &str) -> Option<i64> {


### PR DESCRIPTION
Even though they will always be zero, because milliseconds are required by https://ircv3.net/specs/extensions/server-time and https://ircv3.net/specs/extensions/chathistory