### PR TITLE
Send MOTD after connection registration

### DIFF
--- a/sable_ircd/src/command/handlers/motd.rs
+++ b/sable_ircd/src/command/handlers/motd.rs
@@ -1,18 +1,11 @@
 use super::*;
 
 #[command_handler("MOTD")]
-fn handle_motd(server: &ClientServer, response: &dyn CommandResponse) -> CommandResult {
-    match &server.info_strings.motd {
-        None => response.numeric(make_numeric!(NoMotd)),
-        Some(motd) => {
-            response.numeric(make_numeric!(MotdStart, server.name()));
-            for ele in motd {
-                response.numeric(make_numeric!(Motd, ele))
-            }
-
-            response.numeric(make_numeric!(EndOfMotd));
-        }
-    }
-
+fn handle_motd(
+    server: &ClientServer,
+    response: &dyn CommandResponse,
+    source: UserSource,
+) -> CommandResult {
+    crate::utils::send_motd(server, response, &source)?;
     Ok(())
 }

--- a/sable_ircd/src/server/update_handler.rs
+++ b/sable_ircd/src/server/update_handler.rs
@@ -144,6 +144,8 @@ impl ClientServer {
                 ));
             }
 
+            crate::utils::send_motd(self, &connection, &user)?;
+
             connection.send(message::Mode::new(&user, &user, &user.mode().format()));
 
             connection.send(message::Notice::new(&self.node.name().to_string(), &user,

--- a/sable_ircd/src/utils/mod.rs
+++ b/sable_ircd/src/utils/mod.rs
@@ -1,6 +1,9 @@
 mod channel_names;
 pub use channel_names::*;
 
+mod motd;
+pub use motd::*;
+
 mod numeric_utils;
 pub use numeric_utils::*;
 

--- a/sable_ircd/src/utils/motd.rs
+++ b/sable_ircd/src/utils/motd.rs
@@ -1,0 +1,25 @@
+use crate::errors::*;
+use crate::messages::numeric;
+use crate::messages::*;
+use crate::*;
+use sable_network::prelude::*;
+
+pub fn send_motd(
+    server: &ClientServer,
+    to: impl MessageSink,
+    to_user: &wrapper::User,
+) -> HandleResult {
+    match &server.info_strings.motd {
+        None => to.send(numeric::NoMotd::new().format_for(server, to_user)),
+        Some(motd) => {
+            to.send(numeric::MotdStart::new(server.name()).format_for(server, to_user));
+            for ele in motd {
+                to.send(numeric::Motd::new(ele).format_for(server, to_user))
+            }
+
+            to.send(numeric::EndOfMotd::new().format_for(server, to_user));
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
> Upon successful completion of the registration process, the server MUST send,
> in this order, the RPL_WELCOME (001) [...] The server SHOULD then respond as
> though the client sent the LUSERS command and return the appropriate numerics.
> If the user has client modes set on them automatically upon joining the network,
> the server SHOULD send the client the RPL_UMODEIS (221) reply or a MODE message
> with the client as target, preferably the former. [...] The server MUST then
> respond as though the client sent it the MOTD command, i.e. it must send either
> the successful Message of the Day numerics or the ERR_NOMOTD (422) numeric.

-- https://modern.ircdocs.horse/#connection-registration

Sable doesn't implement LUSERS yet so it's irrelevant; and the bit about user modes is a mistake, servers always send them after the MOTD.