### PR TITLE
Rename sable.libera.chat/account-registration to draft/account-registration

### DIFF
--- a/sable_ircd/src/capability/mod.rs
+++ b/sable_ircd/src/capability/mod.rs
@@ -78,7 +78,7 @@ define_capabilities! (
         // Draft and experimental caps
         ChatHistory:            0x1_0000 => ("draft/chathistory", true),
         PersistentSession:      0x2_0000 => ("sable.libera.chat/persistent-session", true),
-        AccountRegistration:    0x4_0000 => ("sable.libera.chat/account-registration", true),
+        AccountRegistration:    0x4_0000 => ("draft/account-registration", true),
         ChannelRename:          0x8_0000 => ("draft/channel-rename", true),
     }
 );


### PR DESCRIPTION
As far as I can tell, Sable correctly implements the current version of the IRCv3 draft