### PR TITLE
Add support for advertising values in CAP LS 302

### DIFF
--- a/sable_ircd/src/capability/repository.rs
+++ b/sable_ircd/src/capability/repository.rs
@@ -4,7 +4,6 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::sync::{atomic::AtomicBool, Arc};
-use strum::IntoEnumIterator;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct CapabilityEntry {
@@ -24,10 +23,10 @@ impl CapabilityRepository {
     pub fn new() -> Self {
         let mut supported_caps = Vec::new();
 
-        for cap in ClientCapability::iter() {
+        for &(cap, values) in ClientCapability::all().iter() {
             supported_caps.push(CapabilityEntry {
                 cap,
-                values: RwLock::new(Vec::new()),
+                values: RwLock::new(values.iter().map(|v| v.to_string()).collect()),
                 available: AtomicBool::new(cap.is_default()),
             });
         }


### PR DESCRIPTION
It isn't useful yet, but I wrote it while working on draft/account-registration before I realised we didn't need to advertise any of its values.