### PR TITLE
Remove trailing space from RPL_NAMREPLY

### DIFF
--- a/sable_ircd/src/utils/channel_names.rs
+++ b/sable_ircd/src/utils/channel_names.rs
@@ -51,6 +51,7 @@ pub fn send_channel_names(
         }
         current_line.write_fmt(format_args!("{}{} ", p, n))?;
     }
+    current_line.pop(); // Remove trailing space
     lines.push(current_line);
 
     for line in lines {


### PR DESCRIPTION
This is disallowed by https://modern.ircdocs.horse/#rplnamreply-353 and RFC2812; allowed by RFC1459 ambiguous grammar; and only irc2 and Bahamut seem to send such a trailing space.