### PR TITLE
Implement msgid

### DIFF
--- a/sable_ircd/src/capability/mod.rs
+++ b/sable_ircd/src/capability/mod.rs
@@ -12,6 +12,7 @@ mod capability_condition;
 pub use capability_condition::*;
 
 pub mod account_tag;
+pub mod msgid;
 pub mod server_time;
 
 macro_rules! define_capabilities {
@@ -66,6 +67,7 @@ define_capabilities! (
     ClientCapability
     {
         // Stable caps
+        MessageTags:            0x01 => ("message-tags", true),
         ServerTime:             0x02 => ("server-time", true),
         EchoMessage:            0x04 => ("echo-message", true),
         Sasl:                   0x08 => ("sasl", false),

--- a/sable_ircd/src/capability/msgid.rs
+++ b/sable_ircd/src/capability/msgid.rs
@@ -1,0 +1,17 @@
+use base64::prelude::*;
+
+use super::*;
+use crate::messages::OutboundMessageTag;
+use sable_network::id::EventId;
+
+pub fn msgid_tag(event_id: EventId) -> OutboundMessageTag {
+    let mut buf = [0u8; 24];
+    buf[0..8].copy_from_slice(&event_id.server().local().to_le_bytes());
+    buf[8..16].copy_from_slice(&event_id.epoch().local().to_le_bytes());
+    buf[16..24].copy_from_slice(&event_id.local().to_le_bytes());
+    OutboundMessageTag::new(
+        "msgid",
+        Some(BASE64_URL_SAFE_NO_PAD.encode(&buf[..])),
+        ClientCapability::MessageTags,
+    )
+}

--- a/sable_ircd/src/capability/with_tags.rs
+++ b/sable_ircd/src/capability/with_tags.rs
@@ -10,8 +10,9 @@ pub(crate) trait WithSupportedTags {
 impl WithSupportedTags for OutboundClientMessage {
     fn with_tags_from(self, history_entry: &HistoryLogEntry) -> Self {
         let server_time_tag = server_time::server_time_tag(history_entry.timestamp);
+        let msgid_tag = msgid::msgid_tag(history_entry.source_event);
+        let mut result = self.with_tag(server_time_tag).with_tag(msgid_tag);
 
-        let mut result = self.with_tag(server_time_tag);
         if let Some(account_tag) = account_tag::account_tag(&history_entry.details) {
             result = result.with_tag(account_tag);
         }

--- a/sable_ircd/src/command/handlers/tagmsg.rs
+++ b/sable_ircd/src/command/handlers/tagmsg.rs
@@ -1,0 +1,10 @@
+use super::*;
+
+#[command_handler("TAGMSG")]
+async fn handle_tagmsg(_target: TargetParameter<'_>) -> CommandResult {
+    // Ignore, no client tag is supported yet.
+    //
+    // We send CLIENTTAGDENY=* in ISUPPORT, so well-behaved clients should never send
+    // TAGMSGs anyway.
+    Ok(())
+}

--- a/sable_ircd/src/command/mod.rs
+++ b/sable_ircd/src/command/mod.rs
@@ -60,6 +60,7 @@ mod handlers {
     mod quit;
     pub mod register;
     mod rename;
+    mod tagmsg;
     mod topic;
     mod user;
     mod who;

--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -174,6 +174,10 @@ impl ClientServer {
 
         ret.add(ISupportEntry::string("CASEMAPPING", "ascii"));
 
+        // https://ircv3.net/specs/extensions/message-tags#rpl_isupport-tokens
+        // Ignore all client tags, for now.
+        ret.add(ISupportEntry::string("CLIENTTAGDENY", "*"));
+
         ret.add(ISupportEntry::int(
             "HOSTLEN",
             Hostname::LENGTH.try_into().unwrap(),

--- a/sable_network/src/id.rs
+++ b/sable_network/src/id.rs
@@ -44,6 +44,18 @@ object_ids!(ObjectId (ObjectIdGenerator) {
     SaslSession: sequential;
 });
 
+impl ServerId {
+    pub fn local(&self) -> LocalId {
+        self.0
+    }
+}
+
+impl EpochId {
+    pub fn local(&self) -> LocalId {
+        self.0
+    }
+}
+
 impl NicknameId {
     pub fn nick(&self) -> &Nickname {
         &self.0


### PR DESCRIPTION
This includes a minimal implementation of message-tags, in order to be able to send the msgid tag.

The tag looks like this: `msgid=AQAAAAAAAABDjhlmAAAAABAAAAAAAAAA`. I can probably make it more compact when values are small, but I don't think it's worth it.
It also leaks internal ids. Is it a big deal?


My main motivation for this is to be able to run irctest's chathistory tests, which depend on msgid to avoid complexity.