### PR TITLE
chathistory: Fix error handling on timestamp parsing

### DIFF
--- a/sable_ircd/src/command/error.rs
+++ b/sable_ircd/src/command/error.rs
@@ -47,6 +47,17 @@ pub enum CommandError {
     /// The command couldn't be processed successfully; the provided
     /// numeric(messages::UntargetedNumeric) will be sent to the client to notify them
     Numeric(messages::UntargetedNumeric),
+
+    /// The command couldn't be processed successfully; the provided parameters will
+    /// be turned into a [`FAIL` standard
+    /// reply](https://ircv3.net/specs/extensions/standard-replies) and sent to the client
+    /// to notify them
+    Fail {
+        command: &'static str,
+        code: &'static str,
+        context: String,
+        description: String,
+    },
 }
 
 impl From<ValidationError> for CommandError {

--- a/sable_ircd/src/command/handlers/services/mod.rs
+++ b/sable_ircd/src/command/handlers/services/mod.rs
@@ -161,6 +161,10 @@ impl<'a> Command for ServicesCommand<'a> {
                 tracing::warn!("Translating unknown error numeric from services response: {:?}", n);
                 self.notice(format_args!("Unknown error: {}", n.debug_format()));
             }
+            CommandError::Fail { command, code, context, description } => {
+                tracing::warn!("Translating unknown error numeric from services response: {} {} {} :{}", command, code, context, description);
+                self.notice(format_args!("Unknown error: {} {} {} :{}", command, code, context, description));
+            }
         }
     }
 }


### PR DESCRIPTION
1. INVALID_PARAMS was missing a 'context' token
2. INVALID_MSGREFTYPE should be returned on msgid= or unknown reference type