### PR TITLE
Reload info strings on ircd restart

### DIFF
--- a/sable_ircd/src/server/server_type.rs
+++ b/sable_ircd/src/server/server_type.rs
@@ -12,7 +12,6 @@ pub struct ClientServerState {
     auth_state: AuthClientState,
     client_caps: CapabilityRepository,
     listener_state: SavedListenerCollection,
-    info_strings: config::ServerInfoStrings,
 }
 
 #[async_trait]
@@ -107,7 +106,6 @@ impl sable_server::ServerType for ClientServer {
                 .save()
                 .await
                 .map_err(ServerSaveError::IoError)?,
-            info_strings: self.info_strings,
         })
     }
 
@@ -116,6 +114,7 @@ impl sable_server::ServerType for ClientServer {
         state: ClientServerState,
         node: Arc<NetworkNode>,
         history_receiver: UnboundedReceiver<NetworkHistoryUpdate>,
+        config: &Self::ProcessedConfig,
     ) -> std::io::Result<Self> {
         let (auth_send, auth_recv) = unbounded_channel();
         let (action_send, action_recv) = unbounded_channel();
@@ -148,7 +147,7 @@ impl sable_server::ServerType for ClientServer {
             client_caps: state.client_caps,
             history_receiver: Mutex::new(history_receiver),
             listeners: Movable::new(listeners),
-            info_strings: state.info_strings,
+            info_strings: config.info_strings.clone(),
         })
     }
 

--- a/sable_server/src/server_type.rs
+++ b/sable_server/src/server_type.rs
@@ -59,6 +59,7 @@ pub trait ServerType: Send + Sync + Sized + 'static {
         state: Self::Saved,
         node: Arc<NetworkNode>,
         history_receiver: UnboundedReceiver<NetworkHistoryUpdate>,
+        config: &Self::ProcessedConfig,
     ) -> std::io::Result<Self>;
 
     /// Handle a request originating from a remote server

--- a/sable_services/src/server/mod.rs
+++ b/sable_services/src/server/mod.rs
@@ -147,6 +147,7 @@ where
         _state: Self::Saved,
         _node: Arc<NetworkNode>,
         _history_receiver: UnboundedReceiver<sable_network::rpc::NetworkHistoryUpdate>,
+        _config: &Self::ProcessedConfig,
     ) -> std::io::Result<Self> {
         unimplemented!("services can't hot-upgrade");
     }


### PR DESCRIPTION
instead of serializing the loaded strings in the server state