### PR TITLE
Implement MONITOR

### DIFF
--- a/sable_ircd/src/command/handlers/monitor.rs
+++ b/sable_ircd/src/command/handlers/monitor.rs
@@ -1,0 +1,129 @@
+//! Implementation of the UI of [IRCv3 MONITOR](https://ircv3.net/specs/extensions/monitor)
+
+use super::*;
+use crate::monitor::MonitorInsertError;
+use crate::utils::LineWrapper;
+
+const MAX_CONTENT_LENGTH: usize = 300; // Conservative limit to avoid hitting 512 bytes limit
+
+#[command_handler("MONITOR")]
+fn handle_monitor(
+    server: &ClientServer,
+    cmd: &dyn Command,
+    subcommand: &str,
+    targets: Option<&str>,
+) -> CommandResult {
+    match subcommand.to_ascii_uppercase().as_str() {
+        "+" => handle_monitor_add(server, cmd, targets),
+        "-" => handle_monitor_del(server, cmd, targets),
+        "C" => handle_monitor_clear(server, cmd),
+        "L" => handle_monitor_list(server, cmd),
+        "S" => handle_monitor_show(server, cmd),
+        _ => Ok(()), // The spec does not say what to do; existing implementations ignore it
+    }
+}
+
+fn handle_monitor_add(
+    server: &ClientServer,
+    cmd: &dyn Command,
+    targets: Option<&str>,
+) -> CommandResult {
+    let targets = targets
+        .ok_or(CommandError::NotEnoughParameters)? // technically we could just ignore
+        .split(',')
+        .map(|target| Nickname::parse_str(cmd, target))
+        .collect::<Result<Vec<_>, _>>()?; // ditto
+    let mut monitors = server.monitors.write();
+    let res = targets
+        .iter()
+        .map(|&target| monitors.insert(target, cmd.connection_id()))
+        .collect::<Result<(), _>>()
+        .map_err(
+            |MonitorInsertError::TooManyMonitorsPerConnection { max, current }| {
+                CommandError::Numeric(make_numeric!(MonListFull, max, current))
+            },
+        );
+    drop(monitors); // Release lock
+    send_statuses(cmd, targets);
+    res
+}
+
+fn handle_monitor_del(
+    server: &ClientServer,
+    cmd: &dyn Command,
+    targets: Option<&str>,
+) -> CommandResult {
+    let targets = targets
+        .ok_or(CommandError::NotEnoughParameters)? // technically we could just ignore
+        .split(',')
+        .map(|target| Nickname::parse_str(cmd, target))
+        .collect::<Result<Vec<_>, _>>()?; // ditto
+
+    let mut monitors = server.monitors.write();
+    for target in targets {
+        monitors.remove(target, cmd.connection_id());
+    }
+    Ok(())
+}
+
+fn handle_monitor_clear(server: &ClientServer, cmd: &dyn Command) -> CommandResult {
+    server
+        .monitors
+        .write()
+        .remove_connection(cmd.connection_id());
+    Ok(())
+}
+
+fn handle_monitor_list(server: &ClientServer, cmd: &dyn Command) -> CommandResult {
+    // Copying the set of monitors to release lock on `server.monitors` ASAP
+    let monitors: Option<Vec<_>> = server
+        .monitors
+        .read()
+        .monitored_nicks(cmd.connection_id())
+        .map(|monitors| monitors.iter().copied().collect());
+
+    if let Some(monitors) = monitors {
+        LineWrapper::<',', _, _>::new(MAX_CONTENT_LENGTH, monitors.into_iter())
+            .for_each(|line| cmd.numeric(make_numeric!(MonList, &line)));
+    }
+    cmd.numeric(make_numeric!(EndOfMonList));
+
+    Ok(())
+}
+
+fn handle_monitor_show(server: &ClientServer, cmd: &dyn Command) -> CommandResult {
+    // Copying the set of monitors to release lock on `server.monitors` ASAP
+    let monitors: Option<Vec<_>> = server
+        .monitors
+        .read()
+        .monitored_nicks(cmd.connection_id())
+        .map(|monitors| monitors.iter().copied().collect());
+
+    if let Some(monitors) = monitors {
+        send_statuses(cmd, monitors);
+    }
+    Ok(())
+}
+
+fn send_statuses(cmd: &dyn Command, targets: Vec<Nickname>) {
+    let mut online = Vec::new();
+    let mut offline = Vec::new();
+    for target in targets {
+        match cmd.network().user_by_nick(&target) {
+            Ok(user) => online.push(user.nuh()),
+            Err(LookupError::NoSuchNick(_)) => offline.push(target),
+            Err(e) => {
+                tracing::error!(
+                    "Unexpected error while computing online status of {}: {}",
+                    target,
+                    e
+                );
+            }
+        }
+    }
+
+    LineWrapper::<',', _, _>::new(MAX_CONTENT_LENGTH, online.into_iter())
+        .for_each(|line| cmd.numeric(make_numeric!(MonOnline, &line)));
+    LineWrapper::<',', _, _>::new(MAX_CONTENT_LENGTH, offline.into_iter())
+        .for_each(|line| cmd.numeric(make_numeric!(MonOffline, &line)));
+}

--- a/sable_ircd/src/command/mod.rs
+++ b/sable_ircd/src/command/mod.rs
@@ -48,6 +48,7 @@ mod handlers {
     mod kill;
     mod kline;
     mod mode;
+    mod monitor;
     mod motd;
     mod names;
     mod nick;

--- a/sable_ircd/src/lib.rs
+++ b/sable_ircd/src/lib.rs
@@ -70,6 +70,7 @@ use connection_collection::ConnectionCollectionLockHelper;
 mod isupport;
 use isupport::*;
 
+mod monitor;
 mod movable;
 
 pub mod server;

--- a/sable_ircd/src/messages/numeric.rs
+++ b/sable_ircd/src/messages/numeric.rs
@@ -114,6 +114,13 @@ define_messages! {
 
     440(ServicesNotAvailable) => { () => ":Services are not available"},
 
+    // https://ircv3.net/specs/extensions/monitor
+    730(MonOnline)          => { (content: &str )               => ":{content}" },
+    731(MonOffline)         => { (content: &str )               => ":{content}" },
+    732(MonList)            => { (targets: &str)                => ":{targets}" },
+    733(EndOfMonList)       => { ()                             => ":End of MONITOR list" },
+    734(MonListFull)        => { (limit: usize, targets: usize) => "{limit} {targets} :Monitor list is full." },
+
     900(LoggedIn)           => { (account: &Nickname) => "* {account} :You are now logged in as {account}" },  // TODO: <nick>!<ident>@<host> instead of *
     903(SaslSuccess)        => { () => ":SASL authentication successful" },
     904(SaslFail)           => { () => ":SASL authentication failed" },

--- a/sable_ircd/src/messages/source_target.rs
+++ b/sable_ircd/src/messages/source_target.rs
@@ -58,10 +58,7 @@ impl MessageSource for update::HistoricMessageSource {
 
 impl MessageSource for update::HistoricUser {
     fn format(&self) -> String {
-        format!(
-            "{}!{}@{}",
-            self.nickname, self.user.user, self.user.visible_host
-        )
+        self.nuh()
     }
 }
 

--- a/sable_ircd/src/monitor.rs
+++ b/sable_ircd/src/monitor.rs
@@ -1,0 +1,206 @@
+//! Implementation of [IRCv3 MONITOR](https://ircv3.net/specs/extensions/monitor)
+//!
+//! Monitors are connection-specific (not user-wide), and not propagated across the network.
+//! Therefore, they are identified only by a `ConnectionId`.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{anyhow, Context, Result};
+use thiserror::Error;
+
+use crate::make_numeric;
+use crate::messages::MessageSink;
+use crate::prelude::*;
+use crate::ClientServer;
+use client_listener::ConnectionId;
+use sable_network::prelude::*;
+use sable_network::validated::Nickname;
+
+#[derive(Error, Clone, Debug)]
+pub enum MonitorInsertError {
+    #[error("this connection has too many monitors ({current}), maximum is {max}")]
+    /// `current` may be greater than `max` if server configuration was edited.
+    TooManyMonitorsPerConnection { max: usize, current: usize },
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct MonitorSet {
+    pub max_per_connection: usize,
+    monitors_by_connection: HashMap<ConnectionId, HashSet<Nickname>>,
+    monitors_by_nickname: HashMap<Nickname, HashSet<ConnectionId>>,
+}
+
+impl MonitorSet {
+    pub fn new(max_per_connection: usize) -> MonitorSet {
+        MonitorSet {
+            max_per_connection,
+            monitors_by_connection: HashMap::new(),
+            monitors_by_nickname: HashMap::new(),
+        }
+    }
+
+    /// Marks the `nick` as being monitored by the given connection
+    pub fn insert(
+        &mut self,
+        nick: Nickname,
+        monitor: ConnectionId,
+    ) -> Result<(), MonitorInsertError> {
+        let entry = self
+            .monitors_by_connection
+            .entry(monitor)
+            .or_insert_with(HashSet::new);
+        if entry.len() >= self.max_per_connection {
+            return Err(MonitorInsertError::TooManyMonitorsPerConnection {
+                max: self.max_per_connection,
+                current: entry.len(),
+            });
+        }
+        entry.insert(nick);
+        self.monitors_by_nickname
+            .entry(nick)
+            .or_insert_with(HashSet::new)
+            .insert(monitor);
+        Ok(())
+    }
+
+    /// Marks the `nick` as no longer monitored by the given connection
+    ///
+    /// Returns whether the nick was indeed monitored by the connection.
+    pub fn remove(&mut self, nick: Nickname, monitor: ConnectionId) -> bool {
+        self.monitors_by_connection
+            .get_mut(&monitor)
+            .map(|set| set.remove(&nick));
+        self.monitors_by_nickname
+            .get_mut(&nick)
+            .map(|set| set.remove(&monitor))
+            .unwrap_or(false)
+    }
+
+    /// Remove all monitors of a connection
+    ///
+    /// Returns the set of nicks the connection monitored, if any.
+    pub fn remove_connection(&mut self, monitor: ConnectionId) -> Option<HashSet<Nickname>> {
+        let nicks = self.monitors_by_connection.remove(&monitor);
+        if let Some(nicks) = &nicks {
+            for nick in nicks {
+                self.monitors_by_nickname
+                    .get_mut(nick)
+                    .expect("monitors_by_nickname missing nick present in monitors_by_connection")
+                    .remove(&monitor);
+            }
+        }
+        nicks
+    }
+
+    /// Returns all connections monitoring the given nick
+    pub fn nick_monitors(&self, nick: &Nickname) -> Option<&HashSet<ConnectionId>> {
+        self.monitors_by_nickname.get(nick)
+    }
+
+    /// Returns all nicks monitored by the given connection
+    pub fn monitored_nicks(&self, monitor: ConnectionId) -> Option<&HashSet<Nickname>> {
+        self.monitors_by_connection.get(&monitor)
+    }
+}
+
+/// Trait of [`NetworkStateChange`] details that are relevant to connections using
+/// [IRCv3 MONITOR](https://ircv3.net/specs/extensions/monitor) to monitor users.
+pub(crate) trait MonitoredItem: std::fmt::Debug {
+    /// Same as [`try_notify_monitors`] but logs errors instead of returning `Result`.
+    fn notify_monitors(&self, server: &ClientServer) {
+        if let Err(e) = self.try_notify_monitors(server) {
+            tracing::error!("Error while notifying monitors of {:?}: {}", self, e);
+        }
+    }
+
+    /// Send `RPL_MONONLINE`/`RPL_MONOFFLINE` to all connections monitoring nicks involved in this
+    /// event
+    fn try_notify_monitors(&self, server: &ClientServer) -> Result<()>;
+}
+
+impl MonitoredItem for update::NewUser {
+    fn try_notify_monitors(&self, server: &ClientServer) -> Result<()> {
+        notify_monitors(server, &self.user.nickname, || {
+            make_numeric!(MonOnline, &self.user.nuh())
+        })
+    }
+}
+
+impl MonitoredItem for update::UserNickChange {
+    fn try_notify_monitors(&self, server: &ClientServer) -> Result<()> {
+        if self.user.nickname != self.new_nick {
+            // Don't notify on case change
+            notify_monitors(server, &self.user.nickname, || {
+                make_numeric!(MonOffline, &self.user.nickname.to_string())
+            })?;
+            notify_monitors(server, &self.new_nick, || {
+                make_numeric!(
+                    MonOnline,
+                    &update::HistoricUser {
+                        nickname: self.new_nick,
+                        ..self.user.clone()
+                    }
+                    .nuh()
+                )
+            })?;
+        }
+        Ok(())
+    }
+}
+
+impl MonitoredItem for update::UserQuit {
+    fn try_notify_monitors(&self, server: &ClientServer) -> Result<()> {
+        notify_monitors(server, &self.user.nickname, || {
+            make_numeric!(MonOffline, &self.user.nickname.to_string())
+        })
+    }
+}
+
+impl MonitoredItem for update::BulkUserQuit {
+    fn try_notify_monitors(&self, server: &ClientServer) -> Result<()> {
+        self.items
+            .iter()
+            .map(|item| item.try_notify_monitors(server))
+            .collect::<Vec<_>>() // Notify all monitors even if one of them fails halfway
+            .into_iter()
+            .collect()
+    }
+}
+
+fn notify_monitors(
+    server: &ClientServer,
+    nick: &Nickname,
+    mut make_numeric: impl FnMut() -> UntargetedNumeric,
+) -> Result<()> {
+    // Copying the set of monitors to release lock on `server.monitors` ASAP
+    let monitors: Option<Vec<_>> = server
+        .monitors
+        .read()
+        .monitors_by_nickname
+        .get(nick)
+        .map(|monitors| monitors.iter().copied().collect());
+    if let Some(monitors) = monitors {
+        let network = server.network();
+        monitors
+            .into_iter()
+            .map(|monitor| -> Result<()> {
+                let Some(conn) = server.find_connection(monitor) else {
+                    // TODO: Remove from monitors?
+                    return Ok(());
+                };
+                let user_id = conn
+                    .user_id()
+                    .ok_or(anyhow!("Monitor by user with no user_id {:?}", conn.id()))?;
+                let monitor_user = network
+                    .user(user_id)
+                    .context("Could not find monitoring user")?;
+                conn.send(make_numeric().format_for(server, &monitor_user));
+                Ok(())
+            })
+            .collect::<Vec<_>>() // Notify all monitors even if one of them fails halfway
+            .into_iter()
+            .collect()
+    } else {
+        Ok(())
+    }
+}

--- a/sable_ircd/src/server/config.rs
+++ b/sable_ircd/src/server/config.rs
@@ -22,9 +22,11 @@ pub struct RawClientServerConfig {
     pub listeners: Vec<ListenerConfig>,
     #[serde(flatten)]
     pub info_paths: RawServerInfo,
+    #[serde(default)]
+    pub monitor: MonitorConfig,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ServerInfoStrings {
     pub motd: Option<Vec<String>>, // Linewise to not repeatedly split
     pub admin_info: Option<AdminInfo>,
@@ -66,9 +68,32 @@ pub struct AdminInfo {
     pub email: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct MonitorConfig {
+    /// Maximum number of active MONITORs per client connection. Default to 100
+    #[serde(default = "default_max_monitors_per_connection")]
+    pub max_per_connection: u16,
+    // TODO: add a maximum per user and/or per account, specific limits for
+    // authenticated vs unauthenticated users, etc.
+}
+
+impl Default for MonitorConfig {
+    fn default() -> MonitorConfig {
+        MonitorConfig {
+            max_per_connection: 64,
+        }
+    }
+}
+
+fn default_max_monitors_per_connection() -> u16 {
+    MonitorConfig::default().max_per_connection
+}
+
+#[derive(Debug)]
 pub struct ClientServerConfig {
     pub listeners: Vec<ListenerConfig>,
     pub info_strings: ServerInfoStrings,
+    pub monitor: MonitorConfig,
 }
 
 #[derive(Debug, Error)]

--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -36,9 +36,10 @@ pub use async_handler_collection::*;
 mod upgrade;
 
 use self::{
-    config::{RawClientServerConfig, ServerInfoStrings},
+    config::{ClientServerConfig, RawClientServerConfig, ServerInfoStrings},
     message_sink_repository::MessageSinkRepository,
 };
+use crate::monitor::MonitorSet;
 
 pub mod config;
 
@@ -90,6 +91,8 @@ pub struct ClientServer {
 
     // Any general static info (responses for MOTD, ADMIN, and so on)
     pub info_strings: ServerInfoStrings,
+
+    pub monitors: RwLock<MonitorSet>,
 }
 
 impl ClientServer {
@@ -166,11 +169,16 @@ impl ClientServer {
     }
 
     #[tracing::instrument]
-    fn build_basic_isupport() -> ISupportBuilder {
+    fn build_basic_isupport(config: &ClientServerConfig) -> ISupportBuilder {
         let mut ret = ISupportBuilder::new();
         ret.add(ISupportEntry::simple("EXCEPTS"));
         ret.add(ISupportEntry::simple("INVEX"));
         ret.add(ISupportEntry::simple("FNC"));
+
+        ret.add(ISupportEntry::int(
+            "MONITOR",
+            config.monitor.max_per_connection.into(),
+        ));
 
         ret.add(ISupportEntry::string("CASEMAPPING", "ascii"));
 

--- a/sable_ircd/src/server/update_handler.rs
+++ b/sable_ircd/src/server/update_handler.rs
@@ -3,6 +3,7 @@ use sable_network::prelude::update::{HistoricMessageSource, HistoricMessageTarge
 
 use super::*;
 use crate::errors::HandleResult;
+use crate::monitor::MonitoredItem;
 
 impl ClientServer {
     pub(super) fn handle_history_update(&self, update: NetworkHistoryUpdate) -> HandleResult {
@@ -13,6 +14,18 @@ impl ClientServer {
                 let history = self.node.history();
                 if let Some(entry) = history.get(entry_id) {
                     match &entry.details {
+                        NetworkStateChange::NewUser(detail) => {
+                            detail.notify_monitors(&self);
+                        }
+                        NetworkStateChange::UserNickChange(detail) => {
+                            detail.notify_monitors(&self);
+                        }
+                        NetworkStateChange::UserQuit(detail) => {
+                            detail.notify_monitors(&self);
+                        }
+                        NetworkStateChange::BulkUserQuit(detail) => {
+                            detail.notify_monitors(&self);
+                        }
                         NetworkStateChange::NewUserConnection(detail) => {
                             let new_user_connection = detail.clone();
                             drop(history);

--- a/sable_ircd/src/utils/line_wrapper.rs
+++ b/sable_ircd/src/utils/line_wrapper.rs
@@ -1,0 +1,105 @@
+/// Iterator of strings that concatenates input items into lines of a given maximum length
+///
+/// The length is given in **bytes**.
+pub struct LineWrapper<const JOINER: char, Item: AsRef<str>, Iter: IntoIterator<Item = Item>> {
+    line_length: usize,
+    iter: Iter::IntoIter,
+    buf: Option<String>,
+}
+
+impl<const JOINER: char, Item: AsRef<str>, Iter: Iterator<Item = Item>>
+    LineWrapper<JOINER, Item, Iter>
+{
+    pub fn new(line_length: usize, iter: Iter) -> Self {
+        let mut iter = iter.into_iter();
+        LineWrapper {
+            line_length,
+            buf: iter.next().map(|item| {
+                let mut buf = String::with_capacity(line_length);
+                buf.push_str(item.as_ref());
+                buf
+            }),
+            iter: iter,
+        }
+    }
+}
+
+impl<const JOINER: char, Item: AsRef<str>, Iter: Iterator<Item = Item>> Iterator
+    for LineWrapper<JOINER, Item, Iter>
+{
+    type Item = String;
+
+    fn next(&mut self) -> Option<String> {
+        let Some(buf) = &mut self.buf else {
+            return None;
+        };
+
+        while let Some(item) = self.iter.next() {
+            let item = item.as_ref();
+            if buf.as_bytes().len() + JOINER.len_utf8() + item.as_bytes().len() <= self.line_length
+            {
+                buf.push(JOINER);
+                buf.push_str(item);
+            } else {
+                // Line length exceeded; put the item aside for next call and return
+                // the content of the current buffer
+                let line = String::from(buf.as_str()); // Reallocate without the extra capacity
+                buf.clear();
+                buf.push_str(item);
+                return Some(line);
+            }
+        }
+
+        // No more items in the source iterator; return what remains in the buffer
+
+        let mut buf = self.buf.take().unwrap(); // Can't panic, we already checked for None-ness
+        buf.shrink_to_fit();
+        Some(buf)
+    }
+}
+
+#[test]
+fn test_linewrapper() {
+    let items = ["a", "ab", "cde", "f", "ghi", "jklm", "nopqr"];
+
+    assert_eq!(
+        LineWrapper::<' ', _, _>::new(3, items.into_iter()).collect::<Vec<_>>(),
+        vec!["a", "ab", "cde", "f", "ghi", "jklm", "nopqr"]
+    );
+
+    assert_eq!(
+        LineWrapper::<' ', _, _>::new(4, items.into_iter()).collect::<Vec<_>>(),
+        vec!["a ab", "cde", "f", "ghi", "jklm", "nopqr"]
+    );
+
+    assert_eq!(
+        LineWrapper::<' ', _, _>::new(5, items.into_iter()).collect::<Vec<_>>(),
+        vec!["a ab", "cde f", "ghi", "jklm", "nopqr"]
+    );
+
+    assert_eq!(
+        LineWrapper::<' ', _, _>::new(9, items.into_iter()).collect::<Vec<_>>(),
+        vec!["a ab cde", "f ghi", "jklm", "nopqr"]
+    );
+}
+
+#[test]
+fn test_linewrapper_empty() {
+    assert_eq!(
+        LineWrapper::<' ', _, _>::new(3, Vec::<&str>::new().into_iter()).collect::<Vec<_>>(),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn test_linewrapper_single() {
+    assert_eq!(
+        LineWrapper::<' ', _, _>::new(3, ["a"].into_iter()).collect::<Vec<_>>(),
+        vec!["a"]
+    );
+
+    assert_eq!(
+        LineWrapper::<' ', _, _>::new(3, ["abcde"].into_iter()).collect::<Vec<_>>(),
+        vec!["abcde"]
+    );
+}

--- a/sable_ircd/src/utils/mod.rs
+++ b/sable_ircd/src/utils/mod.rs
@@ -12,3 +12,6 @@ pub use time_utils::*;
 
 mod serde_once_cell;
 pub use serde_once_cell::*;
+
+mod line_wrapper;
+pub use line_wrapper::*;

--- a/sable_network/src/network/update.rs
+++ b/sable_network/src/network/update.rs
@@ -16,6 +16,15 @@ pub struct HistoricUser {
     pub account: Option<Nickname>,
 }
 
+impl HistoricUser {
+    pub fn nuh(&self) -> String {
+        format!(
+            "{}!{}@{}",
+            self.nickname, self.user.user, self.user.visible_host
+        )
+    }
+}
+
 /// Some state changes can originate from either users or servers; this enum is used in the
 /// [`NetworkStateChange`] for those changes to describe the source of the change.
 ///


### PR DESCRIPTION
https://ircv3.net/specs/extensions/monitor

The spec requires:

> For this specification, ‘target’ MUST be a valid nick as determined by the IRC daemon.

Existing server implementations choose to either ignore invalid nicks, or send MONOFFLINE then ignore it.
This implementation sends ERRONEOUSNICKNAME instead because I believe it makes more sense, but that's debatable.