### PR TITLE
Simplify mode flags

### DIFF
--- a/sable_ircd/src/command/handlers/mode.rs
+++ b/sable_ircd/src/command/handlers/mode.rs
@@ -69,7 +69,7 @@ async fn handle_user_mode(
     for c in mode_str.chars() {
         if let Ok(d) = Direction::try_from(c) {
             dir = d;
-        } else if let Some(flag) = UserModeSet::flag_for(c) {
+        } else if let Some(flag) = UserModeFlag::from_mode_char(c) {
             if server.policy().can_set_umode(&source, flag).is_err() {
                 continue;
             }
@@ -125,7 +125,7 @@ async fn handle_channel_mode(
     for c in mode_str.chars() {
         if let Ok(d) = Direction::try_from(c) {
             dir = d;
-        } else if let Some(flag) = ChannelModeSet::flag_for(c) {
+        } else if let Some(flag) = ChannelModeFlag::from_mode_char(c) {
             server.policy().can_change_mode(source, &chan, flag)?;
             match dir {
                 Direction::Add => {
@@ -136,7 +136,7 @@ async fn handle_channel_mode(
                 }
                 _ => {}
             }
-        } else if let Some(flag) = MembershipFlagSet::flag_for(c) {
+        } else if let Some(flag) = MembershipFlagFlag::from_mode_char(c) {
             let target = args.next::<wrapper::User>()?;
             let membership = target
                 .is_in_channel(chan.id())

--- a/sable_ircd/src/command/handlers/mode.rs
+++ b/sable_ircd/src/command/handlers/mode.rs
@@ -166,7 +166,7 @@ async fn handle_channel_mode(
                 removed: perm_removed,
             };
             cmd.new_event_with_response(membership.id(), detail).await;
-        } else if let Some(list_type) = ListModeType::from_char(c) {
+        } else if let Some(list_type) = ListModeType::from_mode_char(c) {
             let list = chan.list(list_type);
 
             if dir == Direction::Query || args.is_empty() {
@@ -202,7 +202,7 @@ async fn handle_channel_mode(
                     }
                 }
             }
-        } else if let Some(_key_type) = KeyModeType::from_char(c) {
+        } else if let Some(_key_type) = KeyModeType::from_mode_char(c) {
             match dir {
                 // Can't query keys
                 Direction::Query => (),

--- a/sable_ircd/src/messages/send_history.rs
+++ b/sable_ircd/src/messages/send_history.rs
@@ -158,7 +158,7 @@ impl SendHistoryItem for update::ChannelTopicChange {
 
 impl SendHistoryItem for update::ListModeAdded {
     fn send_to(&self, conn: impl MessageSink, from_entry: &HistoryLogEntry) -> HandleResult {
-        let text = format!("+{} {}", self.list_type.mode_letter(), self.pattern);
+        let text = format!("+{} {}", self.list_type.mode_char(), self.pattern);
         let message =
             message::Mode::new(&self.set_by, &self.channel, &text).with_tags_from(from_entry);
         conn.send(message);
@@ -168,7 +168,7 @@ impl SendHistoryItem for update::ListModeAdded {
 
 impl SendHistoryItem for update::ListModeRemoved {
     fn send_to(&self, conn: impl MessageSink, from_entry: &HistoryLogEntry) -> HandleResult {
-        let text = format!("-{} {}", self.list_type.mode_letter(), self.pattern);
+        let text = format!("-{} {}", self.list_type.mode_char(), self.pattern);
         let message =
             message::Mode::new(&self.removed_by, &self.channel, &text).with_tags_from(from_entry);
         conn.send(message);

--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -158,12 +158,15 @@ impl ClientServer {
     #[tracing::instrument]
     fn build_myinfo() -> MyInfo {
         MyInfo {
-            user_modes: UserModeSet::all().map(|m| m.1).iter().collect(),
-            chan_modes: ChannelModeSet::all().map(|m| m.1).iter().collect(),
+            user_modes: UserModeSet::all().map(|m| m.mode_char()).iter().collect(),
+            chan_modes: ChannelModeSet::all()
+                .map(|m| m.mode_char())
+                .iter()
+                .collect(),
             chan_modes_with_a_parameter: ListModeType::iter()
                 .map(|t| t.mode_letter())
                 .chain(KeyModeType::iter().map(|t| t.mode_letter()))
-                .chain(MembershipFlagSet::all().map(|m| m.1).into_iter())
+                .chain(MembershipFlagSet::all().map(|m| m.mode_char()).into_iter())
                 .collect(),
         }
     }
@@ -198,7 +201,10 @@ impl ClientServer {
         let list_modes: String = ListModeType::iter().map(|t| t.mode_letter()).collect();
         let key_modes: String = KeyModeType::iter().map(|t| t.mode_letter()).collect();
         let param_modes = "";
-        let simple_modes: String = ChannelModeSet::all().map(|m| m.1).iter().collect();
+        let simple_modes: String = ChannelModeSet::all()
+            .map(|m| m.mode_char())
+            .iter()
+            .collect();
         let chanmodes = format!(
             "{},{},{},{}",
             list_modes, key_modes, param_modes, simple_modes
@@ -210,8 +216,14 @@ impl ClientServer {
         // 'msgid' not supported yet
         ret.add(ISupportEntry::string("MSGREFTYPES", "timestamp"));
 
-        let prefix_modes: String = MembershipFlagSet::all().map(|m| m.1).iter().collect();
-        let prefix_chars: String = MembershipFlagSet::all().map(|m| m.2).iter().collect();
+        let prefix_modes: String = MembershipFlagSet::all()
+            .map(|m| m.mode_char())
+            .iter()
+            .collect();
+        let prefix_chars: String = MembershipFlagSet::all()
+            .map(|m| m.prefix_char())
+            .iter()
+            .collect();
 
         let prefix = format!("({}){}", prefix_modes, prefix_chars);
         ret.add(ISupportEntry::string("PREFIX", &prefix));

--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -164,8 +164,8 @@ impl ClientServer {
                 .iter()
                 .collect(),
             chan_modes_with_a_parameter: ListModeType::iter()
-                .map(|t| t.mode_letter())
-                .chain(KeyModeType::iter().map(|t| t.mode_letter()))
+                .map(|t| t.mode_char())
+                .chain(KeyModeType::iter().map(|t| t.mode_char()))
                 .chain(MembershipFlagSet::all().map(|m| m.mode_char()).into_iter())
                 .collect(),
         }
@@ -198,8 +198,8 @@ impl ClientServer {
             Username::LENGTH.try_into().unwrap(),
         ));
 
-        let list_modes: String = ListModeType::iter().map(|t| t.mode_letter()).collect();
-        let key_modes: String = KeyModeType::iter().map(|t| t.mode_letter()).collect();
+        let list_modes: String = ListModeType::iter().map(|t| t.mode_char()).collect();
+        let key_modes: String = KeyModeType::iter().map(|t| t.mode_char()).collect();
         let param_modes = "";
         let simple_modes: String = ChannelModeSet::all()
             .map(|m| m.mode_char())

--- a/sable_network/src/modes.rs
+++ b/sable_network/src/modes.rs
@@ -43,14 +43,14 @@ macro_rules! define_mode_type {
 
         impl $typename
         {
-            pub fn mode_letter(&self) -> char
+            pub fn mode_char(&self) -> char
             {
                 match self {
                     $( Self:: $var => $val ),*
                 }
             }
 
-            pub fn from_char(c: char) -> Option<Self>
+            pub fn from_mode_char(c: char) -> Option<Self>
             {
                 match c {
                     $( $val => Some(Self::$var) ),+,

--- a/sable_network/src/network/wrapper/channel_mode.rs
+++ b/sable_network/src/network/wrapper/channel_mode.rs
@@ -17,7 +17,7 @@ impl ChannelMode<'_> {
     pub fn format(&self) -> String {
         let mut ret = format!("+{}", self.data.modes.to_chars());
         if self.data.key.is_some() {
-            ret.push(KeyModeType::Key.mode_letter());
+            ret.push(KeyModeType::Key.mode_char());
         }
         ret
     }

--- a/sable_network/src/utils/channel_modes.rs
+++ b/sable_network/src/utils/channel_modes.rs
@@ -16,7 +16,7 @@ pub fn format_cmode_changes(detail: &ChannelModeChange) -> (String, Vec<String>)
         changes += "+";
         changes += &detail.added.to_chars();
         if let OptionChange::Set(new_key) = detail.key_change {
-            changes.push(KeyModeType::Key.mode_letter());
+            changes.push(KeyModeType::Key.mode_char());
             params.push(new_key.to_string());
         }
     }
@@ -24,7 +24,7 @@ pub fn format_cmode_changes(detail: &ChannelModeChange) -> (String, Vec<String>)
         changes += "-";
         changes += &detail.removed.to_chars();
         if detail.key_change.is_unset() {
-            changes.push(KeyModeType::Key.mode_letter());
+            changes.push(KeyModeType::Key.mode_char());
             params.push("*".to_string());
         }
     }

--- a/sable_network/src/utils/channel_modes.rs
+++ b/sable_network/src/utils/channel_modes.rs
@@ -42,18 +42,18 @@ pub fn format_channel_perm_changes(
 
     if !added.is_empty() {
         changes += "+";
-        for (flag, modechar, _) in MembershipFlagSet::all() {
+        for flag in MembershipFlagSet::all() {
             if added.is_set(flag) {
-                changes += &modechar.to_string();
+                changes += &flag.mode_char().to_string();
                 args.push(nick.to_string());
             }
         }
     }
     if !removed.is_empty() {
         changes += "-";
-        for (flag, modechar, _) in MembershipFlagSet::all() {
+        for flag in MembershipFlagSet::all() {
             if removed.is_set(flag) {
-                changes += &modechar.to_string();
+                changes += &flag.mode_char().to_string();
                 args.push(nick.to_string());
             }
         }


### PR DESCRIPTION
1. Rename `*Flag::to_char` and `MembershipFlagFlag::to_prefix` to `MembershipFlagFlag::mode_char` and `MembershipFlagFlag::prefix_char`, because the prefix is also a char
2. Remove `*Set::char_for` and `MembershipFlagSet::prefix_for`, they are less efficient duplicates of the above
3. Move `*Set::flag_for` and `MembershipFlagSet::flag_for_prefix` to `*Flag::from_mode_char` and `MembershipFlagFlag::from_prefix_char` because they don't belong on a set and "flag_for" is an unclear name
4. Remove chars from `ALL` and `all()` because they are not needed anymore
5. Removed parser support for specifying extra chars that would be ignored