### PR TITLE
Advertise UTF8ONLY ISUPPORT token

### DIFF
--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -175,6 +175,9 @@ impl ClientServer {
         ret.add(ISupportEntry::simple("INVEX"));
         ret.add(ISupportEntry::simple("FNC"));
 
+        // https://ircv3.net/specs/extensions/utf8-only
+        ret.add(ISupportEntry::simple("UTF8ONLY"));
+
         ret.add(ISupportEntry::int(
             "MONITOR",
             config.monitor.max_per_connection.into(),


### PR DESCRIPTION
We already return an ERROR on non-UTF8 message.

The spec recommends FAIL, but does not require it.