### PR TITLE
WHO: Add support for nick masks

### DIFF
--- a/sable_network/src/lib.rs
+++ b/sable_network/src/lib.rs
@@ -26,6 +26,9 @@ pub mod config;
 pub mod audit;
 
 pub mod types {
+    mod matchers;
+    pub use matchers::*;
+
     mod pattern;
     pub use pattern::*;
 }

--- a/sable_network/src/network/network/accessors.rs
+++ b/sable_network/src/network/network/accessors.rs
@@ -106,6 +106,26 @@ impl Network {
             })
     }
 
+    /// Look up the user currently using the given nickname pattern
+    pub fn users_by_nick_pattern<'a>(
+        &'a self,
+        pattern: &'a NicknameMatcher,
+    ) -> impl Iterator<Item = wrapper::User> + 'a {
+        let pattern = std::rc::Rc::new(pattern);
+        let pattern2 = pattern.clone();
+        let alias_users = self
+            .get_alias_users()
+            .iter()
+            .filter(move |(nick, _)| pattern2.matches(nick))
+            .map(move |(_, user)| User::wrap(self, user));
+        let users = self
+            .nick_bindings
+            .iter()
+            .filter(move |(nick, _)| pattern.matches(nick))
+            .map(move |(_, user)| self.user(user.user).unwrap());
+        alias_users.chain(users)
+    }
+
     /// Remove a user from nick bindings and add it to historical users for that nick
 
     /// Return a nickname binding for the given nick.

--- a/sable_network/src/policy/error.rs
+++ b/sable_network/src/policy/error.rs
@@ -32,6 +32,8 @@ pub enum UserPermissionError {
     ReadOnlyUmode,
     /// User isn't logged in (and needs to be)
     NotLoggedIn,
+    /// That user is invisible, and does not share any channel with the requested
+    Invisible,
 }
 
 /// A permission error for a registration-related operation

--- a/sable_network/src/policy/standard_user_policy.rs
+++ b/sable_network/src/policy/standard_user_policy.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::*;
 
 use UserPermissionError::*;
@@ -23,5 +25,31 @@ impl UserPolicyService for StandardUserPolicy {
 
     fn can_unset_umode(&self, _user: &wrapper::User, _mode: UserModeFlag) -> PermissionResult {
         Ok(())
+    }
+
+    fn can_list_user(&self, to_user: &User, user: &User) -> PermissionResult {
+        if !user.mode().has_mode(UserModeFlag::Invisible) {
+            return Ok(());
+        }
+
+        // If the target user is invisible, check whether they share any channel
+        let mut channels1: HashSet<_> = to_user
+            .channels()
+            .flat_map(|membership| membership.channel().map(|chan| chan.id()))
+            .collect();
+        let mut channels2: HashSet<_> = user
+            .channels()
+            .flat_map(|membership| membership.channel().map(|chan| chan.id()))
+            .collect();
+        if channels1.len() <= channels2.len() {
+            std::mem::swap(&mut channels1, &mut channels2);
+        }
+        for chan in channels2 {
+            if channels1.contains(&chan) {
+                return Ok(());
+            }
+        }
+
+        Err(PermissionError::User(Invisible))
     }
 }

--- a/sable_network/src/policy/user_policy.rs
+++ b/sable_network/src/policy/user_policy.rs
@@ -7,4 +7,7 @@ pub trait UserPolicyService {
     fn can_set_umode(&self, user: &wrapper::User, mode: UserModeFlag) -> PermissionResult;
     /// Determine whether a given user can unset a given user mode on themselves
     fn can_unset_umode(&self, user: &wrapper::User, mode: UserModeFlag) -> PermissionResult;
+    /// Determine whether one user can discover another without knowing their nick
+    /// (eg. with `WHO *`)
+    fn can_list_user(&self, touser: &User, user: &User) -> PermissionResult;
 }

--- a/sable_network/src/types/matchers.rs
+++ b/sable_network/src/types/matchers.rs
@@ -1,94 +1,91 @@
-use crate::prelude::*;
 use std::net::IpAddr;
-use ipnet::IpNet;
+use std::ops::Deref;
 
-#[derive(Debug,Clone,Serialize,Deserialize)]
-pub enum HostMatcher
-{
+use ipnet::IpNet;
+use serde::{Deserialize, Serialize};
+
+use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum HostMatcher {
     Hostname(Pattern),
     Ip(IpNet),
 }
 
-impl HostMatcher
-{
-    pub fn is_host(&self) -> bool
-    {
+impl HostMatcher {
+    pub fn is_host(&self) -> bool {
         matches!(self, Self::Hostname(_))
     }
 
-    pub fn is_ip(&self) -> bool
-    {
+    pub fn is_ip(&self) -> bool {
         matches!(self, Self::Ip(_))
     }
 
-    pub fn matches_host(&self, hostname: &str) -> bool
-    {
-        match self
-        {
+    pub fn matches_host(&self, hostname: &str) -> bool {
+        match self {
             Self::Hostname(pat) => pat.matches(hostname),
-            _ => false
+            _ => false,
         }
     }
 
-    pub fn matches_ip(&self, addr: &IpAddr) -> bool
-    {
-        match self
-        {
+    pub fn matches_ip(&self, addr: &IpAddr) -> bool {
+        match self {
             Self::Ip(mask) => mask.contains(addr),
-            _ => false
+            _ => false,
         }
     }
 
-    pub fn matches(&self, hostname: &str, addr: &IpAddr) -> bool
-    {
-        match self
-        {
+    pub fn matches(&self, hostname: &str, addr: &IpAddr) -> bool {
+        match self {
             Self::Hostname(pat) => pat.matches(hostname),
             Self::Ip(mask) => mask.contains(addr),
         }
     }
 }
 
-pub struct UserHostMatcher
-{
+pub struct UserHostMatcher {
     user: Pattern,
-    host: HostMatcher
+    host: HostMatcher,
 }
 
-impl UserHostMatcher
-{
-    pub fn matches(&self, username: &str, hostname: &str, addr: &IpAddr) -> bool
-    {
+impl UserHostMatcher {
+    pub fn matches(&self, username: &str, hostname: &str, addr: &IpAddr) -> bool {
         self.user.matches(username) && self.host.matches(hostname, addr)
     }
 }
 
 pub struct IpMatcher(IpNet);
 
-impl IpMatcher
-{
-    pub fn matches(&self, addr: &IpAddr) -> bool
-    {
+impl IpMatcher {
+    pub fn matches(&self, addr: &IpAddr) -> bool {
         self.0.contains(addr)
     }
 }
 
 pub struct ExactIpMatcher(IpAddr);
 
-impl ExactIpMatcher
-{
-    pub fn matches(&self, addr: &IpAddr) -> bool
-    {
+impl ExactIpMatcher {
+    pub fn matches(&self, addr: &IpAddr) -> bool {
         &self.0 == addr
     }
 }
 
 pub struct NicknameMatcher(Pattern);
 
-impl NicknameMatcher
-{
-    pub fn matches(&self, nick: &Nickname) -> bool
-    {
+impl Deref for NicknameMatcher {
+    type Target = Pattern;
+
+    fn deref(&self) -> &Pattern {
+        &self.0
+    }
+}
+
+impl NicknameMatcher {
+    pub fn new(pattern: Pattern) -> NicknameMatcher {
+        NicknameMatcher(pattern)
+    }
+
+    pub fn matches(&self, nick: &Nickname) -> bool {
         self.0.matches(nick.as_ref())
     }
 }


### PR DESCRIPTION
And some random rustfmt changes to `matchers.rs` because it was not imported before.

They are supported by every IRCd but Bahamut, as far as I can tell.