### PR TITLE
Implement msgid (based on UUID7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,6 +2171,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "wildmatch",
  "x509-parser",
 ]
@@ -3018,6 +3019,17 @@ dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+dependencies = [
+ "getrandom",
+ "rand",
+ "serde",
 ]
 
 [[package]]

--- a/sable_ircd/src/capability/mod.rs
+++ b/sable_ircd/src/capability/mod.rs
@@ -12,6 +12,7 @@ mod capability_condition;
 pub use capability_condition::*;
 
 pub mod account_tag;
+pub mod msgid;
 pub mod server_time;
 
 macro_rules! define_capabilities {
@@ -66,6 +67,7 @@ define_capabilities! (
     ClientCapability
     {
         // Stable caps
+        MessageTags:            0x01 => ("message-tags", true),
         ServerTime:             0x02 => ("server-time", true),
         EchoMessage:            0x04 => ("echo-message", true),
         Sasl:                   0x08 => ("sasl", false),

--- a/sable_ircd/src/capability/msgid.rs
+++ b/sable_ircd/src/capability/msgid.rs
@@ -1,0 +1,15 @@
+use super::*;
+use crate::messages::OutboundMessageTag;
+use sable_network::history::HistoryItem;
+use sable_network::network::NetworkStateChange;
+
+pub fn msgid_tag(from_update: &impl HistoryItem) -> Option<OutboundMessageTag> {
+    match from_update.change() {
+        NetworkStateChange::NewMessage(detail) => Some(OutboundMessageTag::new(
+            "msgid",
+            Some(detail.message.to_string()),
+            ClientCapability::MessageTags,
+        )),
+        _ => None,
+    }
+}

--- a/sable_ircd/src/capability/with_tags.rs
+++ b/sable_ircd/src/capability/with_tags.rs
@@ -12,6 +12,10 @@ impl WithSupportedTags for OutboundClientMessage {
         let server_time_tag = server_time::server_time_tag(from_update.timestamp());
 
         let mut result = self.with_tag(server_time_tag);
+
+        if let Some(msgid_tag) = msgid::msgid_tag(from_update) {
+            result = result.with_tag(msgid_tag);
+        }
         if let Some(account_tag) = account_tag::account_tag(from_update.change(), net) {
             result = result.with_tag(account_tag);
         }

--- a/sable_ircd/src/command/handlers/notice.rs
+++ b/sable_ircd/src/command/handlers/notice.rs
@@ -57,7 +57,7 @@ async fn handle_notice(
         message_type: state::MessageType::Notice,
         text: msg.to_owned(),
     };
-    cmd.new_event_with_response(server.ids().next_message(), details)
+    cmd.new_event_with_response(MessageId::new(Uuid7::new_now()), details)
         .await;
     Ok(())
 }

--- a/sable_ircd/src/command/handlers/privmsg.rs
+++ b/sable_ircd/src/command/handlers/privmsg.rs
@@ -36,7 +36,7 @@ async fn handle_privmsg(
         message_type: state::MessageType::Privmsg,
         text: msg.to_owned(),
     };
-    cmd.new_event_with_response(server.ids().next_message(), details)
+    cmd.new_event_with_response(MessageId::new(Uuid7::new_now()), details)
         .await;
     Ok(())
 }

--- a/sable_ircd/src/command/handlers/tagmsg.rs
+++ b/sable_ircd/src/command/handlers/tagmsg.rs
@@ -1,0 +1,10 @@
+use super::*;
+
+/// Minimal implementation of TAGMSG that just drops everything, so we can safely
+/// implement https://ircv3.net/specs/extensions/message-tags
+///
+/// `CLIENTTAGDENY=*` tells clients we would drop all tags, anyway.
+#[command_handler("TAGMSG")]
+fn handle_tagmsg() -> CommandResult {
+    Ok(())
+}

--- a/sable_ircd/src/command/mod.rs
+++ b/sable_ircd/src/command/mod.rs
@@ -61,6 +61,7 @@ mod handlers {
     mod quit;
     pub mod register;
     mod rename;
+    mod tagmsg;
     mod topic;
     mod user;
     mod userhost;

--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -188,6 +188,11 @@ impl ClientServer {
 
         ret.add(ISupportEntry::string("CASEMAPPING", "ascii"));
 
+        // https://ircv3.net/specs/extensions/message-tags#rpl_isupport-tokens
+        // Tell clients all client tags are rejected, so conforming clients won't
+        // even try to send TAGMSG (which we don't support yet).
+        ret.add(ISupportEntry::string("CLIENTTAGDENY", "*"));
+
         ret.add(ISupportEntry::int(
             "HOSTLEN",
             Hostname::LENGTH.try_into().unwrap(),

--- a/sable_network/Cargo.toml
+++ b/sable_network/Cargo.toml
@@ -47,6 +47,7 @@ ipnet = { version = "2", features = [ "serde" ] }
 anyhow = "1.0"
 backoff = { version = "0.4.0", features = ["tokio"] }
 chert = { git = "https://github.com/jesopo/chert" }
+uuid = { version = "1.9.1", features = ["v7", "fast-rng", "serde"] }
 
 [dependencies.serde]
 version = "1"

--- a/sable_network/src/id.rs
+++ b/sable_network/src/id.rs
@@ -3,9 +3,29 @@
 use super::modes::ListModeType;
 use super::validated::*;
 use sable_macros::object_ids;
+use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 use thiserror::Error;
+use uuid::Uuid;
 
 pub type LocalId = i64;
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Serialize, Deserialize)]
+pub struct Uuid7(Uuid);
+
+impl Deref for Uuid7 {
+    type Target = Uuid;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Uuid7 {
+    pub fn new_now() -> Self {
+        Self(Uuid::now_v7())
+    }
+}
 
 #[derive(Debug, Error)]
 #[error("Mismatched object ID type for event")]
@@ -22,7 +42,7 @@ object_ids!(ObjectId (ObjectIdGenerator) {
     ChannelTopic: sequential;
     ListMode: (ChannelId,ListModeType);
     ListModeEntry: sequential;
-    Message: sequential;
+    Message: (Uuid7,);
 
     NetworkBan: sequential;
 
@@ -52,6 +72,14 @@ impl HistoricUserId {
 
     pub fn serial(&self) -> u32 {
         self.1
+    }
+}
+
+impl Deref for MessageId {
+    type Target = Uuid7;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/sable_network/tests/data/sample_events.rs
+++ b/sable_network/tests/data/sample_events.rs
@@ -81,7 +81,7 @@ const EVENT_JSON: &str = r###"
       "1": [1,1707606926,4]
     },
     "target": {
-      "Message": [1,1707606926,1]
+      "Message": "018d954d-e2b0-73be-8f43-337709fa3429"
     },
     "details": {
       "NewMessage": {
@@ -174,7 +174,7 @@ const EVENT_JSON: &str = r###"
       "1": [1,1707606926,5]
     },
     "target": {
-      "Message": [2,1707606928,1]
+      "Message": "018d954d-ea80-7461-b32a-f6d9880e1c44"
     },
     "details": {
       "NewMessage": {


### PR DESCRIPTION
Note that, unlike #107, the `msgid` tag is only added to `NewMessage` events, not to any event.