### PR TITLE
Increase MAX_MSG_SIZE to support message-tags

### DIFF
--- a/client_listener/src/lib.rs
+++ b/client_listener/src/lib.rs
@@ -11,7 +11,8 @@
 //! connections will be sent via the provided event channel.
 
 /// Maximum serialised size of a client message
-pub const MAX_MSG_SIZE: u64 = 1024;
+pub const MAX_MSG_SIZE: u64 = 8191 + 512 + 512; // 8k for tags, 512 for non-tag message, 512 slack
+                                                // for bincoding ConnectionEventDetail
 
 /// Maximum serialised size of a control message
 /// NB: this needs to include the size of the TLS cert chain


### PR DESCRIPTION
Technically we don't currently support messages with more than 4kiB of tags (in C2S because there are no server tags, in S2C because we don't relay client tags), but we might as well bump it to 8kiB already, as we are probably going to support relaying client tags soon.