### PR TITLE
rpc: Segregate Services-specific requests and response enum variants

### DIFF
--- a/sable_ircd/src/command/handlers/register.rs
+++ b/sable_ircd/src/command/handlers/register.rs
@@ -73,7 +73,8 @@ async fn do_register_user(
     }
 
     let message =
-        rpc::RemoteServerRequestType::RegisterUser(requested_account, password.to_owned());
+        rpc::RemoteServicesServerRequestType::RegisterUser(requested_account, password.to_owned())
+            .into();
 
     match server
         .node()
@@ -81,7 +82,9 @@ async fn do_register_user(
         .send_remote_request(services_name, message)
         .await
     {
-        Ok(rpc::RemoteServerResponse::LogUserIn(account)) => {
+        Ok(rpc::RemoteServerResponse::Services(rpc::RemoteServicesServerResponse::LogUserIn(
+            account,
+        ))) => {
             server.add_action(CommandAction::state_change(
                 source.id(),
                 event::UserLogin {
@@ -94,7 +97,9 @@ async fn do_register_user(
                 "You have successfully registered",
             ));
         }
-        Ok(rpc::RemoteServerResponse::AlreadyExists) => {
+        Ok(rpc::RemoteServerResponse::Services(
+            rpc::RemoteServicesServerResponse::AlreadyExists,
+        )) => {
             response_to.send(message::Fail::new(
                 "REGISTER",
                 "ACCOUNT_EXISTS",

--- a/sable_ircd/src/command/handlers/services/cs/access.rs
+++ b/sable_ircd/src/command/handlers/services/cs/access.rs
@@ -1,7 +1,7 @@
 use sable_network::{
     network::state::ChannelRoleName,
     policy::RegistrationPolicyService,
-    rpc::{RemoteServerRequestType, RemoteServerResponse},
+    rpc::{RemoteServerResponse, RemoteServicesServerRequestType, RemoteServicesServerResponse},
 };
 
 use super::*;
@@ -87,11 +87,12 @@ async fn access_modify(
 
     let target_access_id = ChannelAccessId::new(source.account.id(), chan.id());
 
-    let request = RemoteServerRequestType::ModifyAccess {
+    let request = RemoteServicesServerRequestType::ModifyAccess {
         source: source.account.id(),
         id: target_access_id,
         role: Some(new_role.id()),
-    };
+    }
+    .into();
     let registration_response = cmd
         .server()
         .node()
@@ -104,7 +105,7 @@ async fn access_modify(
         Ok(RemoteServerResponse::Success) => {
             cmd.notice("Access successfully updated");
         }
-        Ok(RemoteServerResponse::AccessDenied) => {
+        Ok(RemoteServerResponse::Services(RemoteServicesServerResponse::AccessDenied)) => {
             cmd.notice("Access denied");
         }
         Ok(response) => {
@@ -145,11 +146,12 @@ async fn access_delete(
         return Ok(());
     };
 
-    let request = RemoteServerRequestType::ModifyAccess {
+    let request = RemoteServicesServerRequestType::ModifyAccess {
         source: source.account.id(),
         id: target_access.id(),
         role: None,
-    };
+    }
+    .into();
     let registration_response = services_target.send_remote_request(request).await;
 
     tracing::debug!(?registration_response, "Got registration response");
@@ -157,7 +159,7 @@ async fn access_delete(
         Ok(RemoteServerResponse::Success) => {
             cmd.notice("Access successfully updated");
         }
-        Ok(RemoteServerResponse::AccessDenied) => {
+        Ok(RemoteServerResponse::Services(RemoteServicesServerResponse::AccessDenied)) => {
             cmd.notice("Access denied");
         }
         Ok(response) => {

--- a/sable_ircd/src/command/handlers/services/cs/register.rs
+++ b/sable_ircd/src/command/handlers/services/cs/register.rs
@@ -1,4 +1,6 @@
-use sable_network::rpc::{RemoteServerRequestType, RemoteServerResponse};
+use sable_network::rpc::{
+    RemoteServerResponse, RemoteServicesServerRequestType, RemoteServicesServerResponse,
+};
 
 use super::*;
 
@@ -17,7 +19,8 @@ async fn handle_register(
         return Ok(());
     }
 
-    let request = RemoteServerRequestType::RegisterChannel(source.account.id(), channel.id());
+    let request =
+        RemoteServicesServerRequestType::RegisterChannel(source.account.id(), channel.id()).into();
     let registration_response = services_target.send_remote_request(request).await;
 
     tracing::debug!(?registration_response, "Got registration response");
@@ -28,7 +31,7 @@ async fn handle_register(
                 channel.name()
             ));
         }
-        Ok(RemoteServerResponse::AlreadyExists) => {
+        Ok(RemoteServerResponse::Services(RemoteServicesServerResponse::AlreadyExists)) => {
             cmd.notice(format_args!(
                 "Channel {} is already registered",
                 channel.name()

--- a/sable_ircd/src/command/handlers/services/cs/role.rs
+++ b/sable_ircd/src/command/handlers/services/cs/role.rs
@@ -1,7 +1,7 @@
 use sable_network::{
     network::state::ChannelAccessFlag,
     policy::RegistrationPolicyService,
-    rpc::{RemoteServerRequestType, RemoteServerResponse},
+    rpc::{RemoteServerResponse, RemoteServicesServerRequestType, RemoteServicesServerResponse},
 };
 
 use super::*;
@@ -98,11 +98,12 @@ async fn role_edit(
         .policy()
         .can_create_role(&source.account, &chan, &flags)?;
 
-    let request = RemoteServerRequestType::ModifyRole {
+    let request = RemoteServicesServerRequestType::ModifyRole {
         source: source.account.id(),
         id: target_role.id(),
         flags: Some(flags),
-    };
+    }
+    .into();
     let registration_response = services_target.send_remote_request(request).await;
 
     tracing::debug!(?registration_response, "Got registration response");
@@ -110,7 +111,7 @@ async fn role_edit(
         Ok(RemoteServerResponse::Success) => {
             cmd.notice("Role successfully updated");
         }
-        Ok(RemoteServerResponse::AccessDenied) => {
+        Ok(RemoteServerResponse::Services(RemoteServicesServerResponse::AccessDenied)) => {
             cmd.notice("Access denied");
         }
         Ok(response) => {
@@ -150,12 +151,13 @@ async fn role_add(
         .policy()
         .can_create_role(&source.account, &chan, &flags)?;
 
-    let request = RemoteServerRequestType::CreateRole {
+    let request = RemoteServicesServerRequestType::CreateRole {
         source: source.account.id(),
         channel: chan.id(),
         name: target_role_name,
         flags,
-    };
+    }
+    .into();
     let registration_response = services_target.send_remote_request(request).await;
 
     tracing::debug!(?registration_response, "Got registration response");
@@ -163,7 +165,7 @@ async fn role_add(
         Ok(RemoteServerResponse::Success) => {
             cmd.notice("Role successfully updated");
         }
-        Ok(RemoteServerResponse::AccessDenied) => {
+        Ok(RemoteServerResponse::Services(RemoteServicesServerResponse::AccessDenied)) => {
             cmd.notice("Access denied");
         }
         Ok(response) => {
@@ -196,11 +198,12 @@ async fn role_delete(
         .policy()
         .can_edit_role(&source.account, &chan, &target_role)?;
 
-    let request = RemoteServerRequestType::ModifyRole {
+    let request = RemoteServicesServerRequestType::ModifyRole {
         source: source.account.id(),
         id: target_role.id(),
         flags: None,
-    };
+    }
+    .into();
     let registration_response = services_target.send_remote_request(request).await;
 
     tracing::debug!(?registration_response, "Got registration response");
@@ -208,7 +211,7 @@ async fn role_delete(
         Ok(RemoteServerResponse::Success) => {
             cmd.notice("Role successfully updated");
         }
-        Ok(RemoteServerResponse::AccessDenied) => {
+        Ok(RemoteServerResponse::Services(RemoteServicesServerResponse::AccessDenied)) => {
             cmd.notice("Access denied");
         }
         Ok(response) => {

--- a/sable_ircd/src/command/handlers/services/ns/cert.rs
+++ b/sable_ircd/src/command/handlers/services/ns/cert.rs
@@ -1,4 +1,4 @@
-use sable_network::rpc::{RemoteServerRequestType, RemoteServerResponse};
+use sable_network::rpc::{RemoteServerResponse, RemoteServicesServerRequestType};
 
 use super::*;
 
@@ -70,8 +70,11 @@ async fn cert_add(
         return Ok(());
     }
 
-    let req =
-        RemoteServerRequestType::AddAccountFingerprint(source.account.id(), fingerprint.to_owned());
+    let req = RemoteServicesServerRequestType::AddAccountFingerprint(
+        source.account.id(),
+        fingerprint.to_owned(),
+    )
+    .into();
 
     match services.send_remote_request(req).await {
         Ok(RemoteServerResponse::Success) => {
@@ -101,10 +104,11 @@ async fn cert_del(
 ) -> CommandResult {
     let fingerprint = param.require()?;
 
-    let req = RemoteServerRequestType::RemoveAccountFingerprint(
+    let req = RemoteServicesServerRequestType::RemoveAccountFingerprint(
         source.account.id(),
         fingerprint.to_owned(),
-    );
+    )
+    .into();
 
     match services.send_remote_request(req).await {
         Ok(RemoteServerResponse::Success) => {

--- a/sable_ircd/src/command/handlers/services/ns/login.rs
+++ b/sable_ircd/src/command/handlers/services/ns/login.rs
@@ -1,4 +1,5 @@
-use sable_network::{network::event::UserLogin, rpc::RemoteServerResponse};
+use sable_network::network::event::UserLogin;
+use sable_network::rpc::{RemoteServerResponse, RemoteServicesServerResponse};
 
 use super::*;
 
@@ -21,11 +22,12 @@ async fn handle_login(
     };
 
     let login_request =
-        rpc::RemoteServerRequestType::UserLogin(target_account.id(), password.to_string());
+        rpc::RemoteServicesServerRequestType::UserLogin(target_account.id(), password.to_string())
+            .into();
     let login_result = services.send_remote_request(login_request).await;
 
     match login_result {
-        Ok(RemoteServerResponse::LogUserIn(account)) => {
+        Ok(RemoteServerResponse::Services(RemoteServicesServerResponse::LogUserIn(account))) => {
             if account == target_account.id() {
                 cmd.new_event(
                     source.id(),
@@ -44,7 +46,7 @@ async fn handle_login(
                 cmd.notice("Login failed (internal error)");
             }
         }
-        Ok(RemoteServerResponse::InvalidCredentials) => {
+        Ok(RemoteServerResponse::Services(RemoteServicesServerResponse::InvalidCredentials)) => {
             let msg = format!("Invalid credentials for {}", target_account.name());
             cmd.notice(msg);
         }

--- a/sable_network/src/rpc/network_message.rs
+++ b/sable_network/src/rpc/network_message.rs
@@ -33,11 +33,23 @@ pub struct RemoteServerRequest {
     pub response: oneshot::Sender<RemoteServerResponse>,
 }
 
-/// A message to be handled by a services node
+/// A message to be handled by a specific node
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum RemoteServerRequestType {
     /// Simple ping for communication tests
     Ping,
+    Services(RemoteServicesServerRequestType),
+}
+
+impl From<RemoteServicesServerRequestType> for RemoteServerRequestType {
+    fn from(req: RemoteServicesServerRequestType) -> Self {
+        RemoteServerRequestType::Services(req)
+    }
+}
+
+/// A message to be handled by a services node
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum RemoteServicesServerRequestType {
     /// User attempting registration
     /// Parameters: account name being registered, password provided
     RegisterUser(Nickname, String),
@@ -97,6 +109,21 @@ pub enum RemoteServerResponse {
     Success,
     /// Operation not supported by this server
     NotSupported,
+    /// Operation failed, with error message
+    Error(String),
+    /// Response type specific to services servers
+    Services(RemoteServicesServerResponse),
+}
+
+impl From<RemoteServicesServerResponse> for RemoteServerResponse {
+    fn from(resp: RemoteServicesServerResponse) -> Self {
+        RemoteServerResponse::Services(resp)
+    }
+}
+
+/// Remote services server response type
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum RemoteServicesServerResponse {
     /// Operation succeeded, user should be logged in to account
     LogUserIn(AccountId),
     /// SASL response
@@ -111,6 +138,4 @@ pub enum RemoteServerResponse {
     NoAccount,
     /// Channel isn't registered
     ChannelNotRegistered,
-    /// Operation failed, with error message
-    Error(String),
 }

--- a/sable_services/src/server/command/channel_commands.rs
+++ b/sable_services/src/server/command/channel_commands.rs
@@ -75,19 +75,24 @@ impl<DB: DatabaseConnection> ServicesServer<DB> {
         let net = self.node.network();
         let source_account = net.account(source)?;
 
-        let source_access = source_account
-            .has_access_in(access_id.channel())
-            .ok_or(RemoteServerResponse::ChannelNotRegistered)?;
+        let source_access = source_account.has_access_in(access_id.channel()).ok_or(
+            RemoteServerResponse::Services(RemoteServicesServerResponse::ChannelNotRegistered),
+        )?;
 
         if !source_access.has(ChannelAccessFlag::AccessEdit) {
-            return Err(RemoteServerResponse::AccessDenied.into());
+            return Err(
+                RemoteServerResponse::Services(RemoteServicesServerResponse::AccessDenied).into(),
+            );
         }
 
         let target_account = net.account(access_id.account())?;
 
         if let Some(target_access) = target_account.has_access_in(access_id.channel()) {
             if !source_access.role()?.dominates(&target_access.role()?) {
-                return Err(RemoteServerResponse::AccessDenied.into());
+                return Err(RemoteServerResponse::Services(
+                    RemoteServicesServerResponse::AccessDenied,
+                )
+                .into());
             }
         }
 
@@ -97,7 +102,10 @@ impl<DB: DatabaseConnection> ServicesServer<DB> {
 
                 if !source_access.role()?.dominates(&target_role) {
                     // If the source user doesn't have all the flags they're trying to grant, deny
-                    return Err(RemoteServerResponse::AccessDenied.into());
+                    return Err(RemoteServerResponse::Services(
+                        RemoteServicesServerResponse::AccessDenied,
+                    )
+                    .into());
                 }
 
                 let new_access = state::ChannelAccess {
@@ -144,11 +152,17 @@ impl<DB: DatabaseConnection> ServicesServer<DB> {
 
         match source.has_access_in(channel.id()) {
             None => {
-                return Err(RemoteServerResponse::AccessDenied.into());
+                return Err(RemoteServerResponse::Services(
+                    RemoteServicesServerResponse::AccessDenied,
+                )
+                .into());
             }
             Some(access) => {
                 if !access.role()?.flags().is_set(ChannelAccessFlag::RoleEdit) {
-                    return Err(RemoteServerResponse::AccessDenied.into());
+                    return Err(RemoteServerResponse::Services(
+                        RemoteServicesServerResponse::AccessDenied,
+                    )
+                    .into());
                 }
             }
         };
@@ -188,11 +202,17 @@ impl<DB: DatabaseConnection> ServicesServer<DB> {
 
         match source.has_access_in(channel.id()) {
             None => {
-                return Err(RemoteServerResponse::AccessDenied.into());
+                return Err(RemoteServerResponse::Services(
+                    RemoteServicesServerResponse::AccessDenied,
+                )
+                .into());
             }
             Some(access) => {
                 if !access.role()?.flags().is_set(ChannelAccessFlag::RoleEdit) {
-                    return Err(RemoteServerResponse::AccessDenied.into());
+                    return Err(RemoteServerResponse::Services(
+                        RemoteServicesServerResponse::AccessDenied,
+                    )
+                    .into());
                 }
             }
         };

--- a/sable_services/src/server/command/sasl_commands.rs
+++ b/sable_services/src/server/command/sasl_commands.rs
@@ -1,15 +1,15 @@
 use super::*;
 use AuthenticateStatus::*;
-use RemoteServerResponse::Authenticate;
+use RemoteServicesServerResponse::Authenticate;
 
 impl<DB: DatabaseConnection> ServicesServer<DB> {
     pub fn begin_authenticate(&self, session: SaslSessionId, mechanism: String) -> CommandResult {
         if self.sasl_sessions.contains_key(&session) {
-            return Ok(Authenticate(Fail));
+            return Ok(Authenticate(Fail).into());
         }
 
         if !self.sasl_mechanisms.contains_key(&mechanism) {
-            return Ok(Authenticate(Fail));
+            return Ok(Authenticate(Fail).into());
         }
 
         self.sasl_sessions.insert(
@@ -19,26 +19,26 @@ impl<DB: DatabaseConnection> ServicesServer<DB> {
                 mechanism,
             },
         );
-        Ok(Authenticate(InProgress(Vec::new())))
+        Ok(Authenticate(InProgress(Vec::new())).into())
     }
 
     pub fn authenticate(&self, session_id: SaslSessionId, data: Vec<u8>) -> CommandResult {
         let Some(session) = self.sasl_sessions.get(&session_id) else {
-            return Ok(Authenticate(Fail));
+            return Ok(Authenticate(Fail).into());
         };
 
         let Some(mechanism) = self.sasl_mechanisms.get(&session.mechanism) else {
             self.sasl_sessions.remove(&session_id);
-            return Ok(Authenticate(Fail));
+            return Ok(Authenticate(Fail).into());
         };
 
         let response = mechanism.step(self, &session, data)?;
 
-        Ok(Authenticate(response))
+        Ok(Authenticate(response).into())
     }
 
     pub fn abort_authenticate(&self, session_id: SaslSessionId) -> CommandResult {
         self.sasl_sessions.remove(&session_id);
-        Ok(Authenticate(Aborted))
+        Ok(Authenticate(Aborted).into())
     }
 }

--- a/sable_services/src/server/command/user_commands.rs
+++ b/sable_services/src/server/command/user_commands.rs
@@ -37,11 +37,11 @@ impl<DB: DatabaseConnection> ServicesServer<DB> {
                         data: Some(new_account),
                     },
                 );
-                Ok(RemoteServerResponse::LogUserIn(id))
+                Ok(RemoteServicesServerResponse::LogUserIn(id).into())
             }
             Err(DatabaseError::DuplicateId | DatabaseError::DuplicateName) => {
                 tracing::debug!(?account_name, "Duplicate account name/id");
-                Ok(RemoteServerResponse::AlreadyExists)
+                Ok(RemoteServicesServerResponse::AlreadyExists.into())
             }
             Err(error) => {
                 tracing::error!(?error, "Error creating account");
@@ -59,11 +59,11 @@ impl<DB: DatabaseConnection> ServicesServer<DB> {
         match bcrypt::verify(password, &auth.password_hash) {
             Ok(true) => {
                 tracing::debug!("login successful");
-                Ok(RemoteServerResponse::LogUserIn(account_id))
+                Ok(RemoteServicesServerResponse::LogUserIn(account_id).into())
             }
             Ok(false) => {
                 tracing::debug!("wrong password");
-                Ok(RemoteServerResponse::InvalidCredentials)
+                Ok(RemoteServicesServerResponse::InvalidCredentials.into())
             }
             Err(_) => Err("Couldn't verify password".into()),
         }

--- a/sable_services/src/server/mod.rs
+++ b/sable_services/src/server/mod.rs
@@ -140,68 +140,71 @@ where
         tracing::debug!(?req, "Got remote request");
 
         use RemoteServerRequestType::*;
+        use RemoteServicesServerRequestType::*;
 
         let result = match req {
-            RegisterUser(account_name, password) => {
-                tracing::debug!(?account_name, "Got register request");
+            Services(req) => match req {
+                RegisterUser(account_name, password) => {
+                    tracing::debug!(?account_name, "Got register request");
 
-                self.register_user(account_name, password)
-            }
-            UserLogin(account_id, password) => {
-                tracing::debug!(?account_id, "Got login request");
+                    self.register_user(account_name, password)
+                }
+                UserLogin(account_id, password) => {
+                    tracing::debug!(?account_id, "Got login request");
 
-                self.user_login(account_id, password)
-            }
-            RegisterChannel(account_id, channel_id) => {
-                tracing::debug!(?account_id, ?channel_id, "Got channel register request");
+                    self.user_login(account_id, password)
+                }
+                RegisterChannel(account_id, channel_id) => {
+                    tracing::debug!(?account_id, ?channel_id, "Got channel register request");
 
-                self.register_channel(account_id, channel_id)
-            }
-            ModifyAccess { source, id, role } => {
-                tracing::debug!(?source, ?id, ?role, "Got channel access update");
+                    self.register_channel(account_id, channel_id)
+                }
+                ModifyAccess { source, id, role } => {
+                    tracing::debug!(?source, ?id, ?role, "Got channel access update");
 
-                self.modify_channel_access(source, id, role)
-            }
-            CreateRole {
-                source,
-                channel,
-                name,
-                flags,
-            } => {
-                tracing::debug!(?source, ?channel, ?name, ?flags, "Got role creation");
+                    self.modify_channel_access(source, id, role)
+                }
+                CreateRole {
+                    source,
+                    channel,
+                    name,
+                    flags,
+                } => {
+                    tracing::debug!(?source, ?channel, ?name, ?flags, "Got role creation");
 
-                self.create_role(source, channel, name, flags)
-            }
-            ModifyRole { source, id, flags } => {
-                tracing::debug!(?source, ?id, ?flags, "Got modify role");
+                    self.create_role(source, channel, name, flags)
+                }
+                ModifyRole { source, id, flags } => {
+                    tracing::debug!(?source, ?id, ?flags, "Got modify role");
 
-                self.modify_role(source, id, flags)
-            }
-            BeginAuthenticate(session, mechanism) => {
-                tracing::debug!(?session, ?mechanism, "Got begin authenticate");
+                    self.modify_role(source, id, flags)
+                }
+                BeginAuthenticate(session, mechanism) => {
+                    tracing::debug!(?session, ?mechanism, "Got begin authenticate");
 
-                self.begin_authenticate(session, mechanism)
-            }
-            Authenticate(session, data) => {
-                tracing::debug!(?session, ?data, "Got authenticate data");
+                    self.begin_authenticate(session, mechanism)
+                }
+                Authenticate(session, data) => {
+                    tracing::debug!(?session, ?data, "Got authenticate data");
 
-                self.authenticate(session, data)
-            }
-            AbortAuthenticate(session) => {
-                tracing::debug!(?session, "Got abort authenticate");
+                    self.authenticate(session, data)
+                }
+                AbortAuthenticate(session) => {
+                    tracing::debug!(?session, "Got abort authenticate");
 
-                self.abort_authenticate(session)
-            }
-            AddAccountFingerprint(acc, fp) => {
-                tracing::debug!(?acc, ?fp, "Got add fingerprint");
+                    self.abort_authenticate(session)
+                }
+                AddAccountFingerprint(acc, fp) => {
+                    tracing::debug!(?acc, ?fp, "Got add fingerprint");
 
-                self.user_add_fp(acc, fp)
-            }
-            RemoveAccountFingerprint(acc, fp) => {
-                tracing::debug!(?acc, ?fp, "Got remove fingerprint");
+                    self.user_add_fp(acc, fp)
+                }
+                RemoveAccountFingerprint(acc, fp) => {
+                    tracing::debug!(?acc, ?fp, "Got remove fingerprint");
 
-                self.user_del_fp(acc, fp)
-            }
+                    self.user_del_fp(acc, fp)
+                }
+            },
             Ping => {
                 tracing::warn!(?req, "Got unsupported request");
                 Ok(RemoteServerResponse::NotSupported)
@@ -212,10 +215,10 @@ where
             Ok(response) => response,
             Err(CommandError::LookupError(
                 LookupError::NoSuchAccount(_) | LookupError::NoSuchAccountNamed(_),
-            )) => RemoteServerResponse::NoAccount,
+            )) => RemoteServicesServerResponse::NoAccount.into(),
             Err(CommandError::LookupError(
                 LookupError::NoSuchChannelRegistration(_) | LookupError::ChannelNotRegistered(_),
-            )) => RemoteServerResponse::ChannelNotRegistered,
+            )) => RemoteServicesServerResponse::ChannelNotRegistered.into(),
             Err(e) => RemoteServerResponse::Error(e.to_string()),
         }
     }


### PR DESCRIPTION
We are going to add new variants for the history server, and it's probably cleaner to keep them sorted this way.

Note that it changes the wire format.

Actual changes are in `sable_network/src/rpc/network_message.rs`, everything else is just churn.