### PR TITLE
chathistory: Fix target of incoming DMs

### DIFF
--- a/sable_history/src/pg_history_service.rs
+++ b/sable_history/src/pg_history_service.rs
@@ -320,7 +320,7 @@ fn make_historical_event(
         source: format!("{}!{}@{}", source_nick, source_ident, source_vhost),
         source_account,
         message_type: message_type.into(),
-        target: channel.name.clone(), // assume it's the same
+        target: Some(channel.name.clone()), // assume it's the same
         text,
     }
 }

--- a/sable_network/src/history/service.rs
+++ b/sable_network/src/history/service.rs
@@ -113,7 +113,8 @@ pub enum HistoricalEvent {
         timestamp: i64,
         source: String,
         source_account: Option<String>,
-        target: String,
+        /// If `None`, it should be replaced by the recipient's current nick
+        target: Option<String>,
         message_type: MessageType,
         text: String,
     },

--- a/sable_network/src/network/wrapper/message.rs
+++ b/sable_network/src/network/wrapper/message.rs
@@ -60,7 +60,7 @@ impl MessageTarget<'_> {
 impl std::fmt::Display for MessageTarget<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::User(u) => u.nuh().fmt(f),
+            Self::User(u) => u.nick().fmt(f),
             Self::Channel(c) => c.name().fmt(f),
         }
     }

--- a/sable_network/src/network/wrapper/user.rs
+++ b/sable_network/src/network/wrapper/user.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::prelude::*;
 
 /// A wrapper around a [`state::User`]
+#[derive(Debug)]
 pub struct User<'a> {
     network: &'a Network,
     data: &'a state::User,


### PR DESCRIPTION
With the recent changes to the HistoryService interface, the target of incoming DMs was rewritten to be the sender instead of the recipient.