### PR TITLE
Clarify the role of UserPolicyService::can_list_user's arguments

### DIFF
--- a/sable_network/src/policy/user_policy.rs
+++ b/sable_network/src/policy/user_policy.rs
@@ -7,7 +7,7 @@ pub trait UserPolicyService {
     fn can_set_umode(&self, user: &wrapper::User, mode: UserModeFlag) -> PermissionResult;
     /// Determine whether a given user can unset a given user mode on themselves
     fn can_unset_umode(&self, user: &wrapper::User, mode: UserModeFlag) -> PermissionResult;
-    /// Determine whether one user can discover another without knowing their nick
+    /// Determine whether `to_user` can discover `user` without knowing their nick
     /// (eg. with `WHO *`)
-    fn can_list_user(&self, touser: &User, user: &User) -> PermissionResult;
+    fn can_list_user(&self, to_user: &User, user: &User) -> PermissionResult;
 }


### PR DESCRIPTION
And rename touser to to_user for consistency with StandardUserPolicy.