### PR TITLE
Automatically attach preclients to an existing session of the account, if any

### DIFF
--- a/sable_ircd/src/client.rs
+++ b/sable_ircd/src/client.rs
@@ -253,14 +253,17 @@ impl PreClient {
     pub fn can_register(&self) -> bool {
         let can_register_new = self.can_register_new_user();
         let can_attach = self.can_attach_to_user().is_some();
+        let is_negotiating_caps =
+            self.progress_flags.load(Ordering::Relaxed) & ProgressFlag::CapNegotiation as u32 != 0;
 
         tracing::trace!(
             ?self,
             can_register_new,
             can_attach,
+            is_negotiating_caps,
             "PreClient::can_register"
         );
-        can_register_new || can_attach
+        (can_register_new || can_attach) && !is_negotiating_caps
     }
 
     /// Determine whether this connection is ready to register as a new user

--- a/sable_network/src/policy/standard_user_policy.rs
+++ b/sable_network/src/policy/standard_user_policy.rs
@@ -52,4 +52,8 @@ impl UserPolicyService for StandardUserPolicy {
 
         Err(PermissionError::User(Invisible))
     }
+
+    fn auto_attach_session(&self, _user: &wrapper::User) -> bool {
+        true
+    }
 }

--- a/sable_network/src/policy/user_policy.rs
+++ b/sable_network/src/policy/user_policy.rs
@@ -5,9 +5,15 @@ use super::*;
 pub trait UserPolicyService {
     /// Determine whether a given user can set a given user mode on themselves
     fn can_set_umode(&self, user: &wrapper::User, mode: UserModeFlag) -> PermissionResult;
+
     /// Determine whether a given user can unset a given user mode on themselves
     fn can_unset_umode(&self, user: &wrapper::User, mode: UserModeFlag) -> PermissionResult;
+
     /// Determine whether one user can discover another without knowing their nick
     /// (eg. with `WHO *`)
     fn can_list_user(&self, touser: &User, user: &User) -> PermissionResult;
+
+    /// Determine whether a new connection of the given `user` will join an existing
+    /// session if there is any
+    fn auto_attach_session(&self, user: &wrapper::User) -> bool;
 }


### PR DESCRIPTION
Tested with https://github.com/progval/irctest/pull/304 which fails because of:

* https://github.com/Libera-Chat/sable/issues/155
* https://github.com/Libera-Chat/sable/issues/156

TODO:

* [ ] fill the blanks in the `fake_log_entry` objects (or directly call `self.send_now` for both AWAY and JOIN+TOPIC+NAMES? either way it's annoying because the idiomatic ways requires a log entry if we want account-tag and the like)
* [ ] make it configurable? (per-user or per-server)