### PR TITLE
chathistory: Represent 'limit' as NonZeroUsize or Option<NonZeroUsize> instead of usize

### DIFF
--- a/sable_history/src/pg_history_service.rs
+++ b/sable_history/src/pg_history_service.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 
 use anyhow::{bail, Result};
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -32,7 +33,7 @@ impl HistoryService for PgHistoryService<'_> {
         _user: UserId,
         _after_ts: Option<i64>,
         _before_ts: Option<i64>,
-        _limit: Option<usize>,
+        _limit: Option<NonZeroUsize>,
     ) -> HashMap<TargetId, i64> {
         // TODO: access control
         // TODO: after_ts, before_ts, limit
@@ -121,7 +122,7 @@ impl HistoryService for PgHistoryService<'_> {
             .filter(messages::dsl::target_channel.eq(db_channel_id));
         match request {
             HistoryRequest::Latest { to_ts, limit } => {
-                let limit = i64::min(10000, i64::try_from(limit).unwrap_or(i64::MAX));
+                let limit = i64::min(10000, i64::try_from(usize::from(limit)).unwrap_or(i64::MAX));
                 match to_ts {
                     Some(to_ts) => {
                         let to_ts = DateTime::from_timestamp(to_ts, 999_999)
@@ -154,7 +155,7 @@ impl HistoryService for PgHistoryService<'_> {
                 }
             }
             HistoryRequest::Before { from_ts, limit } => {
-                let limit = i64::min(10000, i64::try_from(limit).unwrap_or(i64::MAX));
+                let limit = i64::min(10000, i64::try_from(usize::from(limit)).unwrap_or(i64::MAX));
                 let from_ts = DateTime::from_timestamp(from_ts, 0)
                     .unwrap_or(DateTime::<Utc>::MAX_UTC)
                     .naive_utc();
@@ -171,7 +172,7 @@ impl HistoryService for PgHistoryService<'_> {
                 .await
             }
             HistoryRequest::After { start_ts, limit } => {
-                let limit = i64::min(10000, i64::try_from(limit).unwrap_or(i64::MAX));
+                let limit = i64::min(10000, i64::try_from(usize::from(limit)).unwrap_or(i64::MAX));
                 let start_ts = DateTime::from_timestamp(start_ts, 999_999)
                     .unwrap_or(DateTime::<Utc>::MIN_UTC)
                     .naive_utc();
@@ -188,7 +189,7 @@ impl HistoryService for PgHistoryService<'_> {
                 .await
             }
             HistoryRequest::Around { around_ts, limit } => {
-                let limit = i64::min(10000, i64::try_from(limit).unwrap_or(i64::MAX));
+                let limit = i64::min(10000, i64::try_from(usize::from(limit)).unwrap_or(i64::MAX));
                 let around_ts = DateTime::from_timestamp(around_ts, 0)
                     .unwrap_or(DateTime::<Utc>::MIN_UTC)
                     .naive_utc();
@@ -231,7 +232,8 @@ impl HistoryService for PgHistoryService<'_> {
                     let end_ts = DateTime::from_timestamp(end_ts, 0)
                         .unwrap_or(DateTime::<Utc>::MAX_UTC)
                         .naive_utc();
-                    let limit = i64::min(10000, i64::try_from(limit).unwrap_or(i64::MAX));
+                    let limit =
+                        i64::min(10000, i64::try_from(usize::from(limit)).unwrap_or(i64::MAX));
                     collect_query(
                         connection_lock,
                         &channel,
@@ -251,7 +253,8 @@ impl HistoryService for PgHistoryService<'_> {
                     let end_ts = DateTime::from_timestamp(end_ts, 999_999)
                         .unwrap_or(DateTime::<Utc>::MIN_UTC)
                         .naive_utc();
-                    let limit = i64::min(10000, i64::try_from(limit).unwrap_or(i64::MAX));
+                    let limit =
+                        i64::min(10000, i64::try_from(usize::from(limit)).unwrap_or(i64::MAX));
                     collect_query(
                         connection_lock,
                         &channel,

--- a/sable_ircd/src/command/handlers/chathistory.rs
+++ b/sable_ircd/src/command/handlers/chathistory.rs
@@ -1,4 +1,5 @@
 use std::cmp::{max, min};
+use std::num::NonZeroUsize;
 
 use sable_network::history::{HistoryError, HistoryRequest, HistoryService, TargetId};
 
@@ -35,7 +36,7 @@ fn parse_msgref(subcommand: &str, target: Option<&str>, msgref: &str) -> Result<
     }
 }
 
-fn parse_limit(s: &str) -> Result<usize, CommandError> {
+fn parse_limit(s: &str) -> Result<NonZeroUsize, CommandError> {
     s.parse().map_err(|_| CommandError::Fail {
         command: "CHATHISTORY",
         code: "INVALID_PARAMS",
@@ -165,7 +166,7 @@ async fn list_targets<'a>(
     source: &'a wrapper::User<'_>,
     from_ts: Option<i64>,
     to_ts: Option<i64>,
-    limit: Option<usize>,
+    limit: Option<NonZeroUsize>,
 ) {
     let history_service = server.node().history_service();
 

--- a/sable_network/src/history/remote_service.rs
+++ b/sable_network/src/history/remote_service.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 
 use tracing::instrument;
 
@@ -30,7 +31,7 @@ impl<NetworkPolicy: policy::PolicyService> HistoryService
         user: UserId,
         after_ts: Option<i64>,
         before_ts: Option<i64>,
-        limit: Option<usize>,
+        limit: Option<NonZeroUsize>,
     ) -> HashMap<TargetId, i64> {
         let res = self
             .node

--- a/sable_network/src/history/service.rs
+++ b/sable_network/src/history/service.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::num::NonZeroUsize;
 
 use thiserror::Error;
 
@@ -53,24 +54,24 @@ impl TryFrom<&HistoricMessageTargetId> for TargetId {
 pub enum HistoryRequest {
     Latest {
         to_ts: Option<i64>,
-        limit: usize,
+        limit: NonZeroUsize,
     },
     Before {
         from_ts: i64,
-        limit: usize,
+        limit: NonZeroUsize,
     },
     After {
         start_ts: i64,
-        limit: usize,
+        limit: NonZeroUsize,
     },
     Around {
         around_ts: i64,
-        limit: usize,
+        limit: NonZeroUsize,
     },
     Between {
         start_ts: i64,
         end_ts: i64,
-        limit: usize,
+        limit: NonZeroUsize,
     },
 }
 
@@ -92,7 +93,7 @@ pub trait HistoryService {
         user: UserId,
         after_ts: Option<i64>,
         before_ts: Option<i64>,
-        limit: Option<usize>,
+        limit: Option<NonZeroUsize>,
     ) -> impl Future<Output = HashMap<TargetId, i64>> + Send;
 
     fn get_entries(

--- a/sable_network/src/rpc/network_message.rs
+++ b/sable_network/src/rpc/network_message.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use crate::{
     history::{HistoricalEvent, HistoryError, HistoryRequest},
     id::*,
@@ -106,7 +108,7 @@ pub enum RemoteHistoryServerRequestType {
         user: UserId,
         after_ts: Option<i64>,
         before_ts: Option<i64>,
-        limit: Option<usize>,
+        limit: Option<NonZeroUsize>,
     },
 
     GetEntries {


### PR DESCRIPTION
The zero case is either nonsensical or a special case, and this makes the distinction clearer, and avoids writing code that accidentally forgets to handle the zero case when it should.