### PR TITLE
Remove stabilized features

### DIFF
--- a/sable_ircd/src/lib.rs
+++ b/sable_ircd/src/lib.rs
@@ -1,6 +1,5 @@
 #![allow(rustdoc::private_intra_doc_links)]
 #![allow(incomplete_features)]
-#![feature(trait_upcasting)]
 
 //! IRC client server logic.
 //!

--- a/sable_network/src/lib.rs
+++ b/sable_network/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(round_char_boundary)]
-#![feature(hash_extract_if)]
 
 pub mod prelude;
 


### PR DESCRIPTION
hash_extract_if was stabilized in 1.88.0 and trait_upcasting in 1.86.0