### PR TITLE
Implement LIST command to list all channels

### DIFF
--- a/sable_ircd/src/command/handlers/list.rs
+++ b/sable_ircd/src/command/handlers/list.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+#[command_handler("LIST")]
+fn handle_list(
+    response: &dyn CommandResponse,
+    source: UserSource,
+    net: &Network,
+    target: Option<&str>,
+) -> CommandResult {
+    match target {
+        Some(channel_str) => {
+            // Try to list a specific channel
+            if let Ok(chname) = ChannelName::from_str(channel_str) {
+                if let Ok(channel) = net.channel_by_name(&chname) {
+                    let topic = channel.topic().map(|t| t.text().to_owned()).unwrap_or_default();
+                    let count = channel.members().count();
+                    response.numeric(make_numeric!(ListReply, &channel, count, topic.as_str()));
+                }
+            }
+        }
+        None => {
+            // List all channels
+            for channel in net.channels() {
+                // Only list channels that aren't secret (+s) or that the user is a member of
+                let is_secret = channel.mode().has_mode(ChannelModeFlag::Secret);
+                let is_member = channel.has_member(source.id()).is_some();
+
+                if !is_secret || is_member {
+                    let topic = channel.topic().map(|t| t.text().to_owned()).unwrap_or_default();
+                    let count = channel.members().count();
+                    response.numeric(make_numeric!(ListReply, &channel, count, topic.as_str()));
+                }
+            }
+        }
+    }
+
+    response.numeric(make_numeric!(EndOfList));
+    Ok(())
+}

--- a/sable_ircd/src/command/mod.rs
+++ b/sable_ircd/src/command/mod.rs
@@ -48,6 +48,7 @@ mod handlers {
     mod kick;
     mod kill;
     mod kline;
+    mod list;
     mod links;
     mod mode;
     mod monitor;

--- a/sable_ircd/src/messages/numeric.rs
+++ b/sable_ircd/src/messages/numeric.rs
@@ -56,6 +56,9 @@ define_messages! {
     365(EndOfLinks)             => { ()                         => "* :End of /LINKS list" },
     366(EndOfNames)             => { (chname: &str)             => "{chname} :End of names list" },
 
+    322(ListReply)              => { (chan: &Channel.name(), count: usize, topic: &str) => "{chan} {count} :{topic}" },
+    323(EndOfList)              => { ()                         => ":End of /LIST" },
+
     369(EndOfWhowas)            => { (nick: &Nickname)          => "{nick} :End of /WHOWAS" },
 
     256(AdminMe)                => { (server_name: &ServerName) => "{server_name} :Administrative Info"},


### PR DESCRIPTION
## Summary

- Adds the `/LIST` command (RFC 1459 §4.2.6) so users can enumerate all channels on the server or query a specific channel
- Respects the secret channel mode (`+s`): secret channels are only shown to their members
- Adds numeric replies `322 (RPL_LIST)` and `323 (RPL_LISTEND)`

## Changes

- `sable_ircd/src/command/handlers/list.rs` — new command handler
- `sable_ircd/src/command/mod.rs` — register the handler module
- `sable_ircd/src/messages/numeric.rs` — add `ListReply` (322) and `EndOfList` (323) numerics

## Test plan

- [ ] `/LIST` returns all non-secret channels with member count and topic
- [ ] `/LIST #channel` returns info for that specific channel
- [ ] Secret channels (`+s`) are hidden from non-members, visible to members
- [ ] `323 RPL_LISTEND` is always sent at the end