### PR TITLE
Fix timing attack vulnerability in OPER authentication

### DIFF
--- a/sable_network/src/policy/standard_oper_policy.rs
+++ b/sable_network/src/policy/standard_oper_policy.rs
@@ -48,6 +48,11 @@ impl OperPolicyService for StandardOperPolicy {
 
 impl OperAuthenticationService for StandardOperPolicy {
     fn authenticate(&self, oper_config: &OperConfig, user: &str, pass: &str) -> bool {
-        user == oper_config.name && unix::verify(pass, &oper_config.hash)
+        // Always verify password first to prevent username enumeration via timing attacks
+        // unix::verify is designed to be constant-time
+        let password_ok = unix::verify(pass, &oper_config.hash);
+        let name_ok = user == oper_config.name;
+
+        password_ok && name_ok
     }
 }


### PR DESCRIPTION
## Summary

The previous `authenticate` implementation used short-circuit boolean evaluation:

```rust
user == oper_config.name && unix::verify(pass, &oper_config.hash)
```

This means that when the username is wrong, `unix::verify` (which is designed to be constant-time) is **never called**, so invalid usernames return almost instantly while valid ones take the full bcrypt/sha-crypt verification time. An attacker can use this timing difference to enumerate valid OPER usernames.

## Fix

Always call `unix::verify` first, then check the username:

```rust
let password_ok = unix::verify(pass, &oper_config.hash);
let name_ok = user == oper_config.name;
password_ok && name_ok
```

Both checks now always run, eliminating the timing side-channel.

## Changes

- `sable_network/src/policy/standard_oper_policy.rs`

## Test plan

- [ ] Valid OPER credentials still succeed
- [ ] Invalid username with correct password is rejected
- [ ] Invalid password is rejected