### PR TITLE
Add SAFETY documentation to unsafe blocks

### DIFF
--- a/sable_ircd/src/command/client_command.rs
+++ b/sable_ircd/src/command/client_command.rs
@@ -158,9 +158,16 @@ impl ClientCommand {
         match source {
             InternalCommandSource::PreClient(pc) => CommandSource::PreClient(Arc::clone(pc)),
             InternalCommandSource::User(user_pointer, conn_pointer) => {
-                // Safety: user_pointer points to data inside the object managed by `self.net`,
-                // so will always survive at least as long as `self`. The returned `CommandSource`
-                // creates a borrow of `self.net`, so it can't be removed while that exists.
+                // SAFETY: user_pointer and conn_pointer are raw pointers derived from `net.user()` and
+                // `net.user_connection()` respectively. These pointers reference data stored within the
+                // `Network` object (inside DashMap tables), which is guaranteed to outlive this function
+                // call because:
+                //   1. The `Network` is owned by `ClientCommand` (via Arc) and cannot be dropped while
+                //      any `ClientCommand` instance exists
+                //   2. DashMap only removes entries when explicitly deleted, which requires exclusive
+                //      access or happens through well-defined lifecycle points (user quit)
+                //   3. The returned `CommandSource` captures a borrow of `net`, tying the returned
+                //      references' lifetime to the Network's lifetime
                 let user: &'_ state::User = unsafe { &**user_pointer };
                 let user_conn: &'_ state::UserConnection = unsafe { &**conn_pointer };
                 let user_wrapper = <wrapper::User as wrapper::ObjectWrapper>::wrap(net, user);

--- a/sable_server/src/run.rs
+++ b/sable_server/src/run.rs
@@ -22,6 +22,12 @@ use memfd::*;
 use crate::ServerState;
 
 fn read_upgrade_state<ST: ServerType>(fd: RawFd) -> ServerState<ST> {
+    // SAFETY: The `fd` parameter is a valid file descriptor that was:
+    //   1. Created by `prepare_upgrade()` using `Memfd::into_raw_fd()` in a prior process
+    //   2. Passed through `exec` via the `--upgrade-state-fd` command-line argument
+    //   3. Not closed or duplicated elsewhere
+    // Taking ownership with `from_raw_fd` is safe because we are the exclusive owner
+    // of this fd and the Memfd type will properly close it when dropped.
     let memfd = unsafe { Memfd::from_raw_fd(fd) };
     let file = memfd.as_file();
 


### PR DESCRIPTION
## Summary

Adds `// SAFETY:` comments to the two `unsafe` blocks that currently have none (or only a brief note), documenting the invariants that make each block sound. No logic is changed.

## Changes

### `sable_ircd/src/command/client_command.rs`

Documents why the raw `user_pointer` and `conn_pointer` pointers are valid for the lifetime of the returned `CommandSource`:
1. The `Network` is owned by `ClientCommand` via `Arc` and cannot be dropped while any instance exists
2. DashMap only removes entries through well-defined lifecycle points (user quit), never arbitrarily
3. The returned `CommandSource` captures a borrow of `net`, tying the references' lifetime to the Network

### `sable_server/src/run.rs`

Documents why calling `Memfd::from_raw_fd(fd)` is safe in `read_upgrade_state`:
1. The fd was created by `prepare_upgrade()` in the prior process via `Memfd::into_raw_fd()`
2. It was passed through `exec` via `--upgrade-state-fd` and is not closed or duplicated elsewhere
3. This call site is the exclusive owner

## Test plan

- [ ] `cargo clippy` passes (no new warnings)
- [ ] No functional behaviour changes