### PR TITLE
Add HelpTopic inventory type for non-command help entries

### DIFF
--- a/sable_ircd/src/command/dispatcher.rs
+++ b/sable_ircd/src/command/dispatcher.rs
@@ -14,6 +14,33 @@ pub struct CommandRegistration {
     pub(super) handler: CommandHandlerWrapper,
 }
 
+/// A free-form help topic not tied to a command handler.
+///
+/// Use this for topics that describe concepts rather than commands — for example
+/// channel modes, user modes, or any other subject a user might query with `HELP`.
+///
+/// Register a topic at the call site with [`inventory::submit!`]:
+///
+/// ```rust,ignore
+/// inventory::submit!(HelpTopic {
+///     topic: "CMODE_SECRET",
+///     lines: &[
+///         "CMODE_SECRET (+s)",
+///         "",
+///         "Marks the channel as secret. Secret channels are hidden from /LIST",
+///         "and /WHOIS for users who are not members.",
+///     ],
+/// });
+/// ```
+///
+/// Topics are looked up case-insensitively via [`CommandDispatcher::get_help_topic`].
+pub struct HelpTopic {
+    /// The name of the topic, matched case-insensitively against the argument to `HELP`.
+    pub topic: &'static str,
+    /// Lines of help text returned to the client.
+    pub lines: &'static [&'static str],
+}
+
 /// A command dispatcher. Collects registered command handlers and allows lookup by
 /// command name.
 pub struct CommandDispatcher {
@@ -21,6 +48,7 @@ pub struct CommandDispatcher {
 }
 
 inventory::collect!(CommandRegistration);
+inventory::collect!(HelpTopic);
 
 impl CommandDispatcher {
     /// Construct a default `CommandDispatcher`.
@@ -66,5 +94,20 @@ impl CommandDispatcher {
                 None
             }
         }
+    }
+
+    /// Look up a free-form [`HelpTopic`] by name (case-insensitive).
+    ///
+    /// Returns the topic's lines of text, or `None` if no topic with that name was registered.
+    pub fn get_help_topic(&self, topic: &str) -> Option<&'static [&'static str]> {
+        inventory::iter::<HelpTopic>
+            .into_iter()
+            .find(|t| t.topic.eq_ignore_ascii_case(topic))
+            .map(|t| t.lines)
+    }
+
+    /// Iterate over all registered free-form [`HelpTopic`] entries.
+    pub fn iter_help_topics(&self) -> impl Iterator<Item = &'static HelpTopic> {
+        inventory::iter::<HelpTopic>.into_iter()
     }
 }

--- a/sable_ircd/src/server/mod.rs
+++ b/sable_ircd/src/server/mod.rs
@@ -143,6 +143,20 @@ impl ClientServer {
         &self.client_caps
     }
 
+    /// Look up a free-form help topic by name (case-insensitive).
+    ///
+    /// Returns the help lines registered via [`command::HelpTopic`], or `None` if no matching
+    /// topic was found. Command handlers that implement `HELP` should query this alongside
+    /// the command registry to cover both command docs and concept topics (modes, etc.).
+    pub fn get_help_topic(&self, topic: &str) -> Option<&'static [&'static str]> {
+        self.command_dispatcher.get_help_topic(topic)
+    }
+
+    /// Iterate over all free-form help topics registered via [`command::HelpTopic`].
+    pub fn iter_help_topics(&self) -> impl Iterator<Item = &'static command::HelpTopic> {
+        self.command_dispatcher.iter_help_topics()
+    }
+
     /// Store a [`MessageSink`] to use when processing updates caused by the given event
     pub(crate) fn store_response_sink(
         &self,


### PR DESCRIPTION
## Context

PR #129 is implementing the `HELP` command and identified an open question: command docs (extracted from doc comments by the `command_handler` macro) cover command-specific topics, but there is no place to register help text for **concepts** — channel modes, user modes, ISUPPORT tokens, and so on.

## What this PR adds

A `HelpTopic` type using the same `inventory` pattern already used by `CommandRegistration`, providing a compile-time registry for free-form help entries.

### Usage

Register a topic anywhere in the codebase with `inventory::submit!`:

```rust
inventory::submit!(HelpTopic {
    topic: "CMODE_SECRET",
    lines: &[
        "CMODE_SECRET (+s)",
        "",
        "Marks the channel as secret. Secret channels are hidden from /LIST",
        "and /WHOIS for users who are not members.",
    ],
});
```

Look it up in a command handler:

```rust
// check command docs first, then fall back to free-form topics
if let Some(lines) = server.get_help_topic(&topic) {
    // send 704/705/706 numerics
}
```

### New API

**`CommandDispatcher`**
- `get_help_topic(topic: &str) -> Option<&'static [&'static str]>` — case-insensitive lookup
- `iter_help_topics() -> impl Iterator<Item = &'static HelpTopic>` — enumerate all topics (for listing)

**`ClientServer`** — thin forwards to the above, so command handlers don't need to reach into the dispatcher directly.

## How a HELP handler should combine both registries

```rust
// 1. Check command registry (populated by #[command_handler] doc comments — see #129)
// 2. Fall back to HelpTopic registry (this PR)
let lines = server.get_command_docs(&topic)   // added by #129
    .or_else(|| server.get_help_topic(&topic));

match lines {
    Some(lines) => { /* send 704/705/706 */ }
    None        => { /* send 524 HelpNotFound */ }
}
```

## Changes

- `sable_ircd/src/command/dispatcher.rs` — `HelpTopic` struct, `inventory::collect!(HelpTopic)`, two methods on `CommandDispatcher`
- `sable_ircd/src/server/mod.rs` — forwarding methods on `ClientServer`